### PR TITLE
移除调用require方法时的空格

### DIFF
--- a/src/zrender.js
+++ b/src/zrender.js
@@ -36,9 +36,9 @@ define(
         var log = require('./tool/log');
         var guid = require('./tool/guid');
 
-        var Handler = require( './Handler' );
-        var Painter = require( './Painter' );
-        var Storage = require( './Storage' );
+        var Handler = require('./Handler');
+        var Painter = require('./Painter');
+        var Storage = require('./Storage');
         var Animation = require('./animation/animation');
 
         var _instances = {};    //ZRender实例map索引


### PR DESCRIPTION
在dojo框架中使用zrender时，require( './Handler' )这种格式无法被dojo正确解析到并提前加载模块，应该是dojo的问题，但zrender中能简单的去掉空格以支持dojo
