### PR TITLE
将宏函数移到zrender上

### DIFF
--- a/src/macro.js
+++ b/src/macro.js
@@ -1,0 +1,71 @@
+/**
+ * @file 宏函数
+ * @author hushicai(bluthcy@gmail.com)
+ */
+
+(function (global) {
+    /**
+     * 默认的环境配置
+     *
+     * @type {Object}
+     */
+    var DefaultEnv = {};
+
+    /**
+     * 环境配置
+     *
+     * @type {Object}
+     */
+    var env = DefaultEnv;
+
+
+    /**
+     * 多级属性访问
+     *
+     * @inner
+     * @param {Object} obj 对象
+     * @param {string} key 键
+     * @return {Object|number} 值
+     */
+    function accessByDot(obj, key) {
+        key = (key || '').split('.');
+        while (obj && key.length) {
+            obj = obj[key.shift()];
+        }
+        return obj;
+    }
+
+    var macro = {
+        /**
+         * 更新环境配置
+         *
+         * @public
+         * @param {Object} cfg 环境配置
+         */
+        setEnv: function (cfg) {
+            if (cfg) {
+                env = cfg;
+            }
+        },
+        //  ------------------ 宏函数 ---------------------
+        isDefined: function (key) {
+            return !!accessByDot(env, key);
+        },
+        isNotDefined: function (key) {
+            return !accessByDot(env, key);
+        },
+        isEqual: function (key, value) {
+            return accessByDot(env, key) === value;
+        },
+        isNotEqual: function (key, value) {
+            return accessByDot(env, key) !== value;
+        }
+    };
+
+    if (typeof exports === 'object' && typeof module === 'object') {
+        exports = module.exports = macro;
+    }
+    else if (typeof define === 'function' && define.amd) {
+        define(macro);
+    }
+})(this);


### PR DESCRIPTION
考虑到全局函数问题以及fecs代码规范问题，放弃EC_DEFINED、EC_NOT_DEFINED等形式。

将宏函数封装到zrender/macro下，使用方式：

```javascript
// 宏模块的名称可以不用限制为`macro`
// 在zrender中也可以用相对位置`./macro`、`../macro`等
var macro = require('zrender/macro');

if (macro.isDefined('debugMode') && macro.isDefined('mobile')) {
    console.log('xxxx');
}
```

echarts-optimizer分析文件时，由上往下查找宏模块的声明`var macro = require('zrender/macro')`，找到后，则设置当前宏模块名称为`macro`，继续往下找出`if(macro.isDefined('xxx')) {...}`等宏调用，比较一下宏调用所属的对象名称与当前的宏模块名称，如果一致，则计算if表达式的值，true则保留if分支下的BlockStatement，false则保留else分支下的BlockStatement。

_注意：先声明再调用，否则ast分析不出来。_