### PR TITLE
Fix bug: svg element's className is not string.

### DIFF
--- a/src/Handler.js
+++ b/src/Handler.js
@@ -42,7 +42,8 @@ define(
                           || event.srcElement
                           || event.target;
 
-            return target && target.getAttribute("class").match(config.elementClassName)
+            var className = target && target.getAttribute("class");
+            return className && className.match(config.elementClassName);
         };
 
         var domHandlers = {


### PR DESCRIPTION
Fix bug: svg element's className is not string. If mousemove to svg element, will throw an error.
