### PR TITLE
Change isArray condition to avoid clone object fails

### DIFF
--- a/src/core/util.js
+++ b/src/core/util.js
@@ -28,7 +28,7 @@ define(function(require) {
     function clone(source) {
         if (typeof source == 'object' && source !== null) {
             var result = source;
-            if (source instanceof Array) {
+            if (Object.prototype.toString.call(source) === '[object Array]') {
                 result = [];
                 for (var i = 0, len = source.length; i < len; i++) {
                     result[i] = clone(source[i]);


### PR DESCRIPTION
"instanceof Array" will return false and causing setOption() failed