### PR TITLE
Fix left side of rect not contained.

### DIFF
--- a/src/contain/path.js
+++ b/src/contain/path.js
@@ -341,7 +341,7 @@ define(function (require) {
                         if (containStroke(x0, y0, x1, y0, lineWidth, x, y)
                           || containStroke(x1, y0, x1, y1, lineWidth, x, y)
                           || containStroke(x1, y1, x0, y1, lineWidth, x, y)
-                          || containStroke(x0, y1, x1, y1, lineWidth, x, y)
+                          || containStroke(x0, y1, x0, y0, lineWidth, x, y)
                         ) {
                             return true;
                         }


### PR DESCRIPTION
检测某个点是否在矩形描边之上时，未包含左侧，导致无法交互。