### PR TITLE
修复当起始结束点x坐标相同时，_dashedLineTo方法陷入死循环

### DIFF
--- a/src/core/PathProxy.js
+++ b/src/core/PathProxy.js
@@ -423,14 +423,15 @@ define(function (require) {
             x -= offset * dx;
             y -= offset * dy;
 
-            while ((dx >= 0 && x <= x1) || (dx < 0 && x > x1)) {
+            while ((dx > 0 && x <= x1) || (dx < 0 && x >= x1)
+            || (dx == 0 && ((dy > 0 && y <= y1) || (dy < 0 && y >= y1)))) {
                 idx = this._dashIdx;
                 dash = lineDash[idx];
                 x += dx * dash;
                 y += dy * dash;
                 this._dashIdx = (idx + 1) % nDash;
                 // Skip positive offset
-                if ((dx > 0 && x < x0) || (dx < 0 && x > x0)) {
+                if ((dx > 0 && x < x0) || (dx < 0 && x > x0) || (dy > 0 && y < y0) || (dy < 0 && y > y0)) {
                     continue;
                 }
                 ctx[idx % 2 ? 'moveTo' : 'lineTo'](


### PR DESCRIPTION
在不支持setLineDash方法的浏览器中，_dashedLineTo方法原先的循环条件在绘制x坐标相同的线时会陷入死循环。