### PR TITLE
针对一些浏览器的堆积现象的优化

### DIFF
--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -113,10 +113,18 @@ define(function(require) {
             animator.animation = null;
         },
 
-        _update: function() {
+        _update: function () {
 
             var time = new Date().getTime() - this._pausedTime;
             var delta = time - this._time;
+
+            // 如果 delta 小于 12 就不渲染了
+            // why: 在一些浏览器上当我们切换到后台时，会造成回掉函数堆积
+            //      当切回来时堆积的大量渲染会是浏览器挂掉
+            if (delta < 12) {
+                return;
+            }
+
             var clips = this._clips;
             var len = clips.length;
 


### PR DESCRIPTION
在一些手机浏览器（比如手百）里有堆积现象，渲染量比较大时会把浏览器挂掉。

测试堆积的代码：
```        
        var t = 0;
        var s = 0;
        zr.animation.on('frame', function (deltaTime) {
            t += deltaTime;
            if (t > 3000) {
                s += 3;
                alert(s);
                t = 0;
            }
        });
```
