### PR TITLE
use overridable util.createCanvas for Layer canvas

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -18,12 +18,11 @@ define(function (require) {
      *
      * @inner
      * @param {string} id dom id 待用
-     * @param {string} type dom type，such as canvas, div etc.
      * @param {Painter} painter painter instance
      * @param {number} number
      */
-    function createDom(id, type, painter, dpr) {
-        var newDom = document.createElement(type);
+    function createDom(id, painter, dpr) {
+        var newDom = util.createCanvas();
         var width = painter.getWidth();
         var height = painter.getHeight();
 
@@ -54,7 +53,7 @@ define(function (require) {
         var dom;
         dpr = dpr || config.devicePixelRatio;
         if (typeof id === 'string') {
-            dom = createDom(id, 'canvas', painter, dpr);
+            dom = createDom(id, painter, dpr);
         }
         // Not using isDom because in node it will return false
         else if (util.isObject(id)) {
@@ -127,7 +126,7 @@ define(function (require) {
         createBackBuffer: function () {
             var dpr = this.dpr;
 
-            this.domBack = createDom('back-' + this.id, 'canvas', this.painter, dpr);
+            this.domBack = createDom('back-' + this.id, this.painter, dpr);
             this.ctxBack = this.domBack.getContext('2d');
 
             if (dpr != 1) {


### PR DESCRIPTION
[ECharts allows](https://github.com/ecomfe/echarts/blob/31c35216b64ea5b9397829aefe57b8a1bc185e20/src/echarts.js#L1933) the user to supply a custom method to be used whenever a canvas is created. It does so by overriding `util.createCanvas`. This change makes the canvas `Layer` use `util.createCanvas` so the ECharts users can supply a custom canvas creation method.