### PR TITLE
Fix zlevel bug

### DIFF
--- a/src/Painter.js
+++ b/src/Painter.js
@@ -699,7 +699,7 @@ Painter.prototype = {
                 incrementalLayerCount = 1;
             }
             else {
-                layer = this.getLayer(zlevel + incrementalLayerCount > 0 ? EL_AFTER_INCREMENTAL_INC : 0, this._needsManuallyCompositing);
+                layer = this.getLayer(zlevel + (incrementalLayerCount > 0 ? EL_AFTER_INCREMENTAL_INC : 0), this._needsManuallyCompositing);
             }
 
             if (!layer.__builtin__) {


### PR DESCRIPTION
`zlevel` is limited to `EL_AFTER_INCREMENTAL_INC` or `0`.
I wonder whether it's designed or a bug.

正好用到了正负多层zlevel，发现异常。不知道这里是加了incremental之后的特殊处理还是bug……