### PR TITLE
zr image cache bug

### DIFF
--- a/src/graphic/helper/image.js
+++ b/src/graphic/helper/image.js
@@ -50,7 +50,11 @@ export function createOrUpdateImage(newImageOrSrc, image, hostEl, cb, cbPayload)
             !isImageReady(image) && cachedImgObj.pending.push(pendingWrap);
         }
         else {
-            !image && (image = new Image());
+
+            if(!image || globalImageCache.get(image.__zrImageSrc)){
+                image = new Image();
+            }
+
             image.onload = imageOnLoad;
 
             globalImageCache.put(


### PR DESCRIPTION
从globalImageCache拿cache之前应该判断image是不是已经在cache里了，不然从原key拿到的image映射关系会错乱。