### PR TITLE
Fix memory leak due to non-existing image rendering

### DIFF
--- a/src/graphic/helper/image.js
+++ b/src/graphic/helper/image.js
@@ -51,7 +51,7 @@ export function createOrUpdateImage(newImageOrSrc, image, hostEl, cb, cbPayload)
         }
         else {
             !image && (image = new Image());
-            image.onload = imageOnLoad;
+            image.onload = image.onerror = imageOnLoad;
 
             globalImageCache.put(
                 newImageOrSrc,
@@ -74,7 +74,7 @@ export function createOrUpdateImage(newImageOrSrc, image, hostEl, cb, cbPayload)
 
 function imageOnLoad() {
     var cachedImgObj = this.__cachedImgObj;
-    this.onload = this.__cachedImgObj = null;
+    this.onload = this.onerror = this.__cachedImgObj = null;
 
     for (var i = 0; i < cachedImgObj.pending.length; i++) {
         var pendingWrap = cachedImgObj.pending[i];


### PR DESCRIPTION
Handle non-existing image by clearing `pending` in `globalImageCache` for image `onerror`
See Issue https://github.com/ecomfe/zrender/issues/339