### PR TITLE
fix bug(svg): Apply textRotate to element matrix

### DIFF
--- a/src/svg/graphic.js
+++ b/src/svg/graphic.js
@@ -435,7 +435,9 @@ var svgTextDrawRectText = function (el, rect, textRect) {
         var rotate = -style.textRotation || 0;
         var transform = matrix.create();
         // Apply textRotate to element matrix
-        matrix.rotate(transform, el.transform, rotate);
+        if (el.transform) {
+            matrix.rotate(transform, el.transform, rotate);
+        }
         setTransform(textSvgEl, transform);
     }
 


### PR DESCRIPTION
当 ` el.transform` 为 `null` 时，调用437行语句 `matrix.rotate(transform, el.transform, rotate)` 会报错
具体描述见 https://github.com/ecomfe/zrender/issues/358
