### PR TITLE
fix: bind mouse events in web worker

### DIFF
--- a/src/animation/requestAnimationFrame.js
+++ b/src/animation/requestAnimationFrame.js
@@ -1,12 +1,12 @@
 
 export default (
-    typeof window !== 'undefined'
+    typeof self !== 'undefined'
     && (
         // https://github.com/ecomfe/zrender/issues/189#issuecomment-224919809
-        (window.msRequestAnimationFrame && window.msRequestAnimationFrame.bind(window))
-        || window.requestAnimationFrame
-        || window.mozRequestAnimationFrame
-        || window.webkitRequestAnimationFrame
+        (self.msRequestAnimationFrame && self.msRequestAnimationFrame.bind(window))
+        || self.requestAnimationFrame
+        || self.mozRequestAnimationFrame
+        || self.webkitRequestAnimationFrame
     )
 ) || function (func) {
     setTimeout(func, 16);

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -6,7 +6,7 @@ import Eventful from '../mixin/Eventful';
 import env from './env';
 import {isCanvasEl, transformCoordWithViewport} from './dom';
 
-var isDomLevel2 = (typeof window !== 'undefined') && !!window.addEventListener;
+var isDomLevel2 = typeof addEventListener === 'function';
 
 var MOUSE_EVENT_REG = /^(?:mouse|pointer|contextmenu|drag|drop)|click/;
 var _calcOut = [];

--- a/src/zrender.js
+++ b/src/zrender.js
@@ -130,7 +130,7 @@ var ZRender = function (id, dom, opts) {
     this.storage = storage;
     this.painter = painter;
 
-    var handlerProxy = (!env.node && !env.worker) ? new HandlerProxy(painter.getViewportRoot(), painter.root) : null;
+    var handlerProxy = !env.node ? new HandlerProxy(painter.getViewportRoot(), painter.root) : null;
     this.handler = new Handler(storage, painter, handlerProxy, painter.root);
 
     /**
@@ -450,4 +450,3 @@ ZRender.prototype = {
         delInstance(this.id);
     }
 };
-


### PR DESCRIPTION
Web workers do support addEventListener ( aka. EventTarget ) and `requestAnimationFrame`, but worker do not have the global object window.

Instead of window, we should use a better option to get the global object. [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) is the best option indeed, but we can't use it due to its poor compatibility. Browser and worker both support [self](https://developer.mozilla.org/en-US/docs/Web/API/Window/self), and it has very good browser compatibility. Using `self` can be a better option than using window.

This PR generally enables [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) support of zrender, which may greatly improve the performance of echarts.

Ref: https://github.com/apache/incubator-echarts/issues/9232