### PR TITLE
Fix/fix sankey shorty segment

### DIFF
--- a/src/core/PathProxy.js
+++ b/src/core/PathProxy.js
@@ -97,9 +97,11 @@ PathProxy.prototype = {
     /**
      * @readOnly
      */
-    setScale: function (sx, sy) {
-        this._ux = mathAbs(1 / dpr / sx) || 0;
-        this._uy = mathAbs(1 / dpr / sy) || 0;
+    setScale: function (sx, sy, segmentIgnoreThreshold) {
+        // Compat. Previously there is no segmentIgnoreThreshold.
+        segmentIgnoreThreshold = segmentIgnoreThreshold || 0;
+        this._ux = mathAbs(segmentIgnoreThreshold / dpr / sx) || 0;
+        this._uy = mathAbs(segmentIgnoreThreshold / dpr / sy) || 0;
     },
 
     getContext: function () {

--- a/src/graphic/CompoundPath.js
+++ b/src/graphic/CompoundPath.js
@@ -31,7 +31,7 @@ export default Path.extend({
             if (!paths[i].path) {
                 paths[i].createPathProxy();
             }
-            paths[i].path.setScale(scale[0], scale[1]);
+            paths[i].path.setScale(scale[0], scale[1], paths[i].segmentIgnoreThreshold);
         }
     },
 

--- a/src/graphic/Path.js
+++ b/src/graphic/Path.js
@@ -35,10 +35,10 @@ Path.prototype = {
 
     strokeContainThreshold: 5,
 
-    // This item default to be false. but in map series,
-    // in order to improve performance, this will be true,
-    // so the shorty segment won't be drew.
-    segmentIgnoreThreshold: false,
+    // This item default to be false. But in map series in echarts,
+    // in order to improve performance, it should be set to true,
+    // so the shorty segment won't draw.
+    segmentIgnoreThreshold: 0,
 
     /**
      * See `module:zrender/src/graphic/helper/subPixelOptimize`.
@@ -95,7 +95,7 @@ Path.prototype = {
 
         // Update path sx, sy
         var scale = this.getGlobalScale();
-        this.segmentIgnoreThreshold !== false && path.setScale(scale[0], scale[1]);
+        path.setScale(scale[0], scale[1], this.segmentIgnoreThreshold);
 
         // Proxy context
         // Rebuild path in following 2 cases

--- a/src/graphic/Path.js
+++ b/src/graphic/Path.js
@@ -35,6 +35,9 @@ Path.prototype = {
 
     strokeContainThreshold: 5,
 
+    // This item default to be false. but in map series,
+    // in order to improve performance, this will be true,
+    // so the shorty segment won't be drew.
     segmentIgnoreThreshold: false,
 
     /**

--- a/src/graphic/Path.js
+++ b/src/graphic/Path.js
@@ -35,6 +35,8 @@ Path.prototype = {
 
     strokeContainThreshold: 5,
 
+    segmentIgnoreThreshold: false,
+
     /**
      * See `module:zrender/src/graphic/helper/subPixelOptimize`.
      * @type {boolean}
@@ -90,7 +92,7 @@ Path.prototype = {
 
         // Update path sx, sy
         var scale = this.getGlobalScale();
-        path.setScale(scale[0], scale[1]);
+        this.segmentIgnoreThreshold !== false && path.setScale(scale[0], scale[1]);
 
         // Proxy context
         // Rebuild path in following 2 cases


### PR DESCRIPTION
Add segmentIgnoreThreshold setting in Path.js, to fix some shorty line can't be drawn in Sankey.