### PR TITLE
Support `calculateTextPosition ` for some custom shape.

### DIFF
--- a/src/contain/text.js
+++ b/src/contain/text.js
@@ -142,14 +142,14 @@ export function adjustTextY(y, height, textVerticalAlign) {
 }
 
 /**
- * Follow same interface to `Displayable.prototype.interpretTextPosition`.
+ * Follow same interface to `Displayable.prototype.calculateTextPosition`.
  * @public
  * @param {Obejct} [out] Prepared out object. If not input, auto created in the method.
  * @param {module:zrender/graphic/Style} style where `textPosition` and `textDistance` are visited.
  * @param {Object} rect {x, y, width, height} Rect of the host elment, according to which the text positioned.
  * @return {Object} The input `out`. Set: {x, y, textAlign, textVerticalAlign}
  */
-export function interpretTextPosition(out, style, rect) {
+export function calculateTextPosition(out, style, rect) {
     var textPosition = style.textPosition;
     var distance = style.textDistance;
 
@@ -256,7 +256,7 @@ export function interpretTextPosition(out, style, rect) {
  */
 export function adjustTextPositionOnRect(textPosition, rect, distance) {
     var dummyStyle = {textPosition: textPosition, textDistance: distance};
-    return interpretTextPosition({}, dummyStyle, rect);
+    return calculateTextPosition({}, dummyStyle, rect);
 }
 
 /**

--- a/src/contain/text.js
+++ b/src/contain/text.js
@@ -142,13 +142,16 @@ export function adjustTextY(y, height, textVerticalAlign) {
 }
 
 /**
+ * Follow same interface to `Displayable.prototype.interpretTextPosition`.
  * @public
- * @param {stirng} textPosition
- * @param {Object} rect {x, y, width, height}
- * @param {number} distance
- * @return {Object} {x, y, textAlign, textVerticalAlign}
+ * @param {Obejct} [out] Prepared out object. If not input, auto created in the method.
+ * @param {module:zrender/graphic/Style} style where `textPosition` and `textDistance` are visited.
+ * @param {Object} rect {x, y, width, height} Rect of the host elment, according to which the text positioned.
+ * @return {Object} The input `out`. Set: {x, y, textAlign, textVerticalAlign}
  */
-export function adjustTextPositionOnRect(textPosition, rect, distance) {
+export function interpretTextPosition(out, style, rect) {
+    var textPosition = style.textPosition;
+    var distance = style.textDistance;
 
     var x = rect.x;
     var y = rect.y;
@@ -233,12 +236,27 @@ export function adjustTextPositionOnRect(textPosition, rect, distance) {
             break;
     }
 
-    return {
-        x: x,
-        y: y,
-        textAlign: textAlign,
-        textVerticalAlign: textVerticalAlign
-    };
+    out = out || {};
+    out.x = x;
+    out.y = y;
+    out.textAlign = textAlign;
+    out.textVerticalAlign = textVerticalAlign;
+
+    return out;
+}
+
+/**
+ * To be removed. But still do not remove in case that some one has imported it.
+ * @deprecated
+ * @public
+ * @param {stirng} textPosition
+ * @param {Object} rect {x, y, width, height}
+ * @param {number} distance
+ * @return {Object} {x, y, textAlign, textVerticalAlign}
+ */
+export function adjustTextPositionOnRect(textPosition, rect, distance) {
+    var dummyStyle = {textPosition: textPosition, textDistance: distance};
+    return interpretTextPosition({}, dummyStyle, rect);
 }
 
 /**

--- a/src/graphic/Displayable.js
+++ b/src/graphic/Displayable.js
@@ -265,7 +265,28 @@ Displayable.prototype = {
         this.style = new Style(obj, this);
         this.dirty(false);
         return this;
-    }
+    },
+
+    /**
+     * The string value of `textPosition` needs to be interpreted to a real postion.
+     * For example, `'inside'` is interpreted to `[rect.width/2, rect.height/2]`
+     * by default. See `contain/text.js#interpretTextPosition` for more details.
+     * But some coutom shapes like "pin", "flag" have center that is not exactly
+     * `[width/2, height/2]`. So we provide this hook to customize the interpretation
+     * for those shapes. It will be called if the `style.textPosition` is a string.
+     * @param {Obejct} [out] Prepared out object. If not provided, this method should
+     *        be responsible for creating one.
+     * @param {module:zrender/graphic/Style} style
+     * @param {Object} rect {x, y, width, height}
+     * @return {Obejct} out The same as the input out.
+     *         {
+     *             x: number. mandatory.
+     *             y: number. mandatory.
+     *             textAlign: string. optional. use style.textAlign by default.
+     *             textVerticalAlign: string. optional. use style.textVerticalAlign by default.
+     *         }
+     */
+    interpretTextPosition: null
 };
 
 zrUtil.inherits(Displayable, Element);

--- a/src/graphic/Displayable.js
+++ b/src/graphic/Displayable.js
@@ -268,11 +268,11 @@ Displayable.prototype = {
     },
 
     /**
-     * The string value of `textPosition` needs to be interpreted to a real postion.
-     * For example, `'inside'` is interpreted to `[rect.width/2, rect.height/2]`
-     * by default. See `contain/text.js#interpretTextPosition` for more details.
+     * The string value of `textPosition` needs to be calculated to a real postion.
+     * For example, `'inside'` is calculated to `[rect.width/2, rect.height/2]`
+     * by default. See `contain/text.js#calculateTextPosition` for more details.
      * But some coutom shapes like "pin", "flag" have center that is not exactly
-     * `[width/2, height/2]`. So we provide this hook to customize the interpretation
+     * `[width/2, height/2]`. So we provide this hook to customize the calculation
      * for those shapes. It will be called if the `style.textPosition` is a string.
      * @param {Obejct} [out] Prepared out object. If not provided, this method should
      *        be responsible for creating one.
@@ -286,7 +286,7 @@ Displayable.prototype = {
      *             textVerticalAlign: string. optional. use style.textVerticalAlign by default.
      *         }
      */
-    interpretTextPosition: null
+    calculateTextPosition: null
 };
 
 zrUtil.inherits(Displayable, Element);

--- a/src/graphic/helper/text.js
+++ b/src/graphic/helper/text.js
@@ -505,9 +505,9 @@ function getBoxPosition(out, hostEl, style, rect) {
             baseY = rect.y + parsePercent(textPosition[1], rect.height);
         }
         else {
-            var res = (hostEl && hostEl.interpretTextPosition)
-                ? hostEl.interpretTextPosition(_tmpTextPositionResult, style, rect)
-                : textContain.interpretTextPosition(_tmpTextPositionResult, style, rect);
+            var res = (hostEl && hostEl.calculateTextPosition)
+                ? hostEl.calculateTextPosition(_tmpTextPositionResult, style, rect)
+                : textContain.calculateTextPosition(_tmpTextPositionResult, style, rect);
             baseX = res.x;
             baseY = res.y;
             // Default align and baseline when has textPosition

--- a/src/graphic/helper/text.js
+++ b/src/graphic/helper/text.js
@@ -26,6 +26,8 @@ var SHADOW_STYLE_COMMON_PROPS = [
     ['textShadowOffsetY', 'shadowOffsetY', 0],
     ['textShadowColor', 'shadowColor', 'transparent']
 ];
+var _tmpTextPositionResult = {};
+var _tmpBoxPositionResult = {};
 
 /**
  * @param {module:zrender/graphic/Style} style
@@ -144,7 +146,7 @@ function renderPlainText(hostEl, ctx, text, style, rect, prevEl) {
     var textLines = contentBlock.lines;
     var lineHeight = contentBlock.lineHeight;
 
-    var boxPos = getBoxPosition(outerHeight, style, rect);
+    var boxPos = getBoxPosition(_tmpBoxPositionResult, hostEl, style, rect);
     var baseX = boxPos.baseX;
     var baseY = boxPos.baseY;
     var textAlign = boxPos.textAlign || 'left';
@@ -255,7 +257,7 @@ function drawRichText(hostEl, ctx, contentBlock, style, rect) {
     var outerHeight = contentBlock.outerHeight;
     var textPadding = style.textPadding;
 
-    var boxPos = getBoxPosition(outerHeight, style, rect);
+    var boxPos = getBoxPosition(_tmpBoxPositionResult, hostEl, style, rect);
     var baseX = boxPos.baseX;
     var baseY = boxPos.baseY;
     var textAlign = boxPos.textAlign;
@@ -488,7 +490,7 @@ function onBgImageLoaded(image, textBackgroundColor) {
     textBackgroundColor.image = image;
 }
 
-function getBoxPosition(blockHeiht, style, rect) {
+function getBoxPosition(out, hostEl, style, rect) {
     var baseX = style.x || 0;
     var baseY = style.y || 0;
     var textAlign = style.textAlign;
@@ -503,9 +505,9 @@ function getBoxPosition(blockHeiht, style, rect) {
             baseY = rect.y + parsePercent(textPosition[1], rect.height);
         }
         else {
-            var res = textContain.adjustTextPositionOnRect(
-                textPosition, rect, style.textDistance
-            );
+            var res = (hostEl && hostEl.interpretTextPosition)
+                ? hostEl.interpretTextPosition(_tmpTextPositionResult, style, rect)
+                : textContain.interpretTextPosition(_tmpTextPositionResult, style, rect);
             baseX = res.x;
             baseY = res.y;
             // Default align and baseline when has textPosition
@@ -522,13 +524,15 @@ function getBoxPosition(blockHeiht, style, rect) {
         }
     }
 
-    return {
-        baseX: baseX,
-        baseY: baseY,
-        textAlign: textAlign,
-        textVerticalAlign: textVerticalAlign
-    };
+    out = out || {};
+    out.baseX = baseX;
+    out.baseY = baseY;
+    out.textAlign = textAlign;
+    out.textVerticalAlign = textVerticalAlign;
+
+    return out;
 }
+
 
 function setCtx(ctx, prop, value) {
     ctx[prop] = fixShadow(ctx, prop, value);

--- a/src/svg/graphic.js
+++ b/src/svg/graphic.js
@@ -309,6 +309,7 @@ svgImage.brush = function (el) {
 var svgText = {};
 export {svgText as text};
 var tmpRect = new BoundingRect();
+var tmpTextPositionResult = {};
 
 var svgTextDrawRectText = function (el, rect, textRect) {
     var style = el.style;
@@ -334,7 +335,6 @@ var svgTextDrawRectText = function (el, rect, textRect) {
     var x;
     var y;
     var textPosition = style.textPosition;
-    var distance = style.textDistance;
     var align = style.textAlign || 'left';
 
     if (typeof style.fontSize === 'number') {
@@ -363,9 +363,9 @@ var svgTextDrawRectText = function (el, rect, textRect) {
         y = rect.y + textPosition[1];
     }
     else {
-        var newPos = textContain.adjustTextPositionOnRect(
-            textPosition, rect, distance
-        );
+        var newPos = el.interpretTextPosition
+            ? el.interpretTextPosition(tmpTextPositionResult, style, rect)
+            : textContain.interpretTextPosition(tmpTextPositionResult, style, rect);
         x = newPos.x;
         y = newPos.y;
         verticalAlign = newPos.textVerticalAlign;

--- a/src/svg/graphic.js
+++ b/src/svg/graphic.js
@@ -363,9 +363,9 @@ var svgTextDrawRectText = function (el, rect, textRect) {
         y = rect.y + textPosition[1];
     }
     else {
-        var newPos = el.interpretTextPosition
-            ? el.interpretTextPosition(tmpTextPositionResult, style, rect)
-            : textContain.interpretTextPosition(tmpTextPositionResult, style, rect);
+        var newPos = el.calculateTextPosition
+            ? el.calculateTextPosition(tmpTextPositionResult, style, rect)
+            : textContain.calculateTextPosition(tmpTextPositionResult, style, rect);
         x = newPos.x;
         y = newPos.y;
         verticalAlign = newPos.textVerticalAlign;

--- a/src/vml/graphic.js
+++ b/src/vml/graphic.js
@@ -875,7 +875,6 @@ if (!env.canvasSupported) {
 
         if (!fromTextEl) {
             var textPosition = style.textPosition;
-            var distance = style.textDistance;
             // Text position represented by coord
             if (textPosition instanceof Array) {
                 x = rect.x + parsePercent(textPosition[0], rect.width);
@@ -884,9 +883,9 @@ if (!env.canvasSupported) {
                 align = align || 'left';
             }
             else {
-                var res = textContain.adjustTextPositionOnRect(
-                    textPosition, rect, distance
-                );
+                var res = this.interpretTextPosition
+                    ? this.interpretTextPosition({}, style, rect)
+                    : textContain.interpretTextPosition({}, style, rect);
                 x = res.x;
                 y = res.y;
 

--- a/src/vml/graphic.js
+++ b/src/vml/graphic.js
@@ -883,9 +883,9 @@ if (!env.canvasSupported) {
                 align = align || 'left';
             }
             else {
-                var res = this.interpretTextPosition
-                    ? this.interpretTextPosition({}, style, rect)
-                    : textContain.interpretTextPosition({}, style, rect);
+                var res = this.calculateTextPosition
+                    ? this.calculateTextPosition({}, style, rect)
+                    : textContain.calculateTextPosition({}, style, rect);
                 x = res.x;
                 y = res.y;
 


### PR DESCRIPTION
Add an approach to customize the inerpretation of `textPosition` for some shape like 'pin', 'flag', whose center is not exactly `[w / 2, h / 2]`.