### PR TITLE
fix(svg): arc large bug #496

### DIFF
--- a/src/svg/graphic.js
+++ b/src/svg/graphic.js
@@ -142,18 +142,20 @@ function pathDataToString(path) {
 
                 var dThetaPositive = Math.abs(dTheta);
                 var isCircle = isAroundZero(dThetaPositive - PI2)
-                    && !isAroundZero(dThetaPositive);
+                    || (clockwise ? dTheta >= PI2 : -dTheta >= PI2);
+
+                // Mapping to 0~2PI
+                var unifiedTheta = dTheta > 0 ? dTheta % PI2 : (dTheta % PI2 + PI2);
 
                 var large = false;
-                if (dThetaPositive >= PI2) {
+                if (isCircle) {
                     large = true;
                 }
                 else if (isAroundZero(dThetaPositive)) {
                     large = false;
                 }
                 else {
-                    large = (dTheta > -PI && dTheta < 0 || dTheta > PI)
-                        === !!clockwise;
+                    large = (unifiedTheta >= PI) === !!clockwise;
                 }
 
                 var x0 = round4(cx + rx * mathCos(theta));

--- a/test/svg-arc.html
+++ b/test/svg-arc.html
@@ -7,23 +7,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
 <body>
-    <div id="main" style="width:1000px;height:800px;"></div>
+    <div id="main" style="width:1000px;height:900px;"></div>
 
     <script type="text/javascript">
 
     // 初始化zrender
     var zr = zrender.init(document.getElementById('main'), {
-        renderer: 'svg'
+        // renderer: 'svg'
     });
 
-    for (var i = 0; i < 8; ++i) {
+    for (var i = 0; i < 16; ++i) {
         var s = 0 + Math.PI / 4 * i;
-        for (var j = 0; j < 8; ++j) {
+        for (var j = 0; j < 16; ++j) {
             var e = Math.PI / 4 * j;
             var arc = new zrender.Arc({
                 shape: {
-                    cx: 50 + 100 * i,
-                    cy: 50 + 100 * j,
+                    cx: 50 + 50 * i,
+                    cy: 50 + 50 * j,
                     r: 20
                 },
                 style: {
@@ -33,18 +33,28 @@
             zr.add(arc);
             var arc = new zrender.Arc({
                 shape: {
-                    cx: 50 + 100 * i,
-                    cy: 50 + 100 * j,
+                    cx: 50 + 50 * i,
+                    cy: 50 + 50 * j,
                     r: 20,
                     startAngle: s,
                     endAngle: e,
                     clockwise: true
                 },
                 style: {
-                    stroke: '#f00'
+                    stroke: '#f00',
+                    fill: 'rgba(255, 255, 0, 0.3)'
                 }
             });
             zr.add(arc);
+
+            var text = new zrender.Text({
+                style: {
+                    text: i + ',' + j,
+                    fontSize: 12
+                },
+                position: [40 + 50 * i, 40 + 50 * j]
+            });
+            zr.add(text);
         }
     }
     </script>

--- a/test/svg-arc.html
+++ b/test/svg-arc.html
@@ -11,9 +11,8 @@
 
     <script type="text/javascript">
 
-    // 初始化zrender
     var zr = zrender.init(document.getElementById('main'), {
-        // renderer: 'svg'
+        renderer: 'svg'
     });
 
     for (var i = 0; i < 16; ++i) {


### PR DESCRIPTION
It fixes the bug with arc `large` value whose `endAngle` is greater than `Math.PI * 2`. It fixes and closes #496.

---

Canvas result of `text/svg-arc.html` (SVG is expected to be the same): 
![canvas](https://user-images.githubusercontent.com/779050/65489688-3da76f80-dede-11e9-8d62-2f6a121b5f03.png)
The number in the circle represents the `(i, j)` value, and the circles are of `startAngle` to be `Math.PI / 4 * i` and `endAngles` to be `Math.PI / 4 * j`.

Before this fix, the SVG result is (wrong parts are highlighted with blue):
![before-svg](https://user-images.githubusercontent.com/779050/65490018-f077cd80-dede-11e9-8bb9-554ddafbad20.png)
This is mainly because the `large` calculation was wrong with `endAngle - startAngle` larger than `Math.PI * 2`.

---

After this fix, the SVG result is (difference with the Canvas result is in blue):
![svg-after](https://user-images.githubusercontent.com/779050/65490606-08038600-dee0-11e9-8bfb-294813df0f5f.png)

I think currently the SVG result is correct, although we cannot say it's a bug with Canvas. Maybe we should adjust the behavior of Canvas cases.

[The Canvas spec](https://html.spec.whatwg.org/multipage/canvas.html#ellipse-method-steps) doesn't have a specific definition about this case and I tested Chrome and Firefox and they have different implementation about it. I created a [demo on jsfiddle](https://jsfiddle.net/ovilia/hzjgfq0e/14/) with circles of `endAngle - startAngle` to be `Math.PI * 2`.

Chrome renders 3PI to 5PI to be a circle, while Firefox renders an empty result.

I'd suggest merging this PR as the SVG results are the same as expected. As about Canvas, we could consider drawing a circle for all these cases.