### PR TITLE
fix: fix text cache bug in SVG, 

### DIFF
--- a/src/contain/text.js
+++ b/src/contain/text.js
@@ -411,8 +411,11 @@ methods.measureText = function (text, font) {
  * @param {string} text
  * @param {string} font
  * @param {Object} [truncate]
- * @return {Object} block: {lineHeight, lines, height, outerHeight}
+ * @return {Object} block: {lineHeight, lines, height, outerHeight, canCacheByTextString}
  *  Notice: for performance, do not calculate outerWidth util needed.
+ *  `canCacheByTextString` means the result `lines` is only determined by the input `text`.
+ *  Thus we can simply comparing the `input` text to determin whether the result changed,
+ *  without travel the result `lines`.
  */
 export function parsePlainText(text, font, padding, textLineHeight, truncate) {
     text != null && (text += '');
@@ -421,12 +424,14 @@ export function parsePlainText(text, font, padding, textLineHeight, truncate) {
     var lines = text ? text.split('\n') : [];
     var height = lines.length * lineHeight;
     var outerHeight = height;
+    var canCacheByTextString = true;
 
     if (padding) {
         outerHeight += padding[0] + padding[2];
     }
 
     if (text && truncate) {
+        canCacheByTextString = false;
         var truncOuterHeight = truncate.outerHeight;
         var truncOuterWidth = truncate.outerWidth;
         if (truncOuterHeight != null && outerHeight > truncOuterHeight) {
@@ -453,7 +458,8 @@ export function parsePlainText(text, font, padding, textLineHeight, truncate) {
         lines: lines,
         height: height,
         outerHeight: outerHeight,
-        lineHeight: lineHeight
+        lineHeight: lineHeight,
+        canCacheByTextString: canCacheByTextString
     };
 }
 


### PR DESCRIPTION
fix: fix text cache bug in SVG, which is brought by commit, which is brought by commit 61a0d3d0bb79977064e3b406732b09b2a3b333ab

Use `echarts/test/treemap-simple.html` to test it please (where text truncate is used):
Steps:
(1) Zoom in util some text disappear.
(2) Zoom out, the text should be able to display again.

