### PR TITLE
WIP(svg): clear text when mouse leaves

### DIFF
--- a/src/svg/Painter.js
+++ b/src/svg/Painter.js
@@ -243,8 +243,8 @@ SVGPainter.prototype = {
             else if (!item.removed) {
                 for (var k = 0; k < item.count; k++) {
                     var displayable = newVisibleList[item.indices[k]];
-                    prevSvgElement = getTextSvgElement(displayable)
-                        || getSvgElement(displayable) || prevSvgElement;
+                    var svgElement = getSvgElement(displayable);
+                    var textSvgElement = getTextSvgElement(displayable);
 
                     var svgElement = getSvgElement(displayable);
                     var textSvgElement = getTextSvgElement(displayable);
@@ -258,6 +258,12 @@ SVGPainter.prototype = {
                         .addWithoutUpdate(svgElement || textSvgElement, displayable);
 
                     this.clipPathManager.markUsed(displayable);
+
+                    if (textSvgElement) { // Insert text.
+                        insertAfter(svgRoot, textSvgElement, svgElement);
+                    }
+                    prevSvgElement = svgElement
+                        || textSvgElement || prevSvgElement;
                 }
             }
         }

--- a/src/svg/graphic.js
+++ b/src/svg/graphic.js
@@ -514,6 +514,8 @@ function removeOldTextNode(el) {
     if (el && el.__textSvgEl) {
         el.__textSvgEl.parentNode.removeChild(el.__textSvgEl);
         el.__textSvgEl = null;
+        el.__tspanList = [];
+        el.__text = null;
     }
 }
 

--- a/src/svg/graphic.js
+++ b/src/svg/graphic.js
@@ -254,6 +254,9 @@ svgPath.brush = function (el) {
     if (style.text != null) {
         svgTextDrawRectText(el, el.getBoundingRect());
     }
+    else {
+        removeOldTextNode(el);
+    }
 };
 
 /***************************************************
@@ -302,6 +305,9 @@ svgImage.brush = function (el) {
 
     if (style.text != null) {
         svgTextDrawRectText(el, el.getBoundingRect());
+    }
+    else {
+        removeOldTextNode(el);
     }
 };
 
@@ -504,11 +510,21 @@ function updateTextLocation(tspan, textAlign, x, y) {
     attr(tspan, 'y', y);
 }
 
+function removeOldTextNode(el) {
+    if (el && el.__textSvgEl) {
+        el.__textSvgEl.parentNode.removeChild(el.__textSvgEl);
+        el.__textSvgEl = null;
+    }
+}
+
 svgText.drawRectText = svgTextDrawRectText;
 
 svgText.brush = function (el) {
     var style = el.style;
     if (style.text != null) {
         svgTextDrawRectText(el, false);
+    }
+    else {
+        removeOldTextNode(el);
     }
 };


### PR DESCRIPTION
Fix https://github.com/apache/incubator-echarts/issues/11543 .

This commit can remove the text. But when the mouse hovers on the circle again, the text doesn't show up.