### PR TITLE
support page event.

### DIFF
--- a/src/Handler.js
+++ b/src/Handler.js
@@ -6,6 +6,7 @@ import * as eventTool from './core/event';
 import GestureMgr from './core/GestureMgr';
 
 var SILENT = 'silent';
+var countListener = Eventful.countListener;
 
 function makeEventPacket(eveType, targetInfo, event) {
     return {
@@ -24,6 +25,7 @@ function makeEventPacket(eveType, targetInfo, event) {
         pinchScale: event.pinchScale,
         wheelDelta: event.zrDelta,
         zrByTouch: event.zrByTouch,
+        zrIsFromLocal: event.zrIsFromLocal,
         which: event.which,
         stop: stopEvent
     };
@@ -36,10 +38,13 @@ function stopEvent(event) {
 function EmptyProxy() {}
 EmptyProxy.prototype.dispose = function () {};
 
+
 var handlerNames = [
     'click', 'dblclick', 'mousewheel', 'mouseout',
-    'mouseup', 'mousedown', 'mousemove', 'contextmenu'
+    'mouseup', 'mousedown', 'mousemove', 'contextmenu',
+    'pagemousemove', 'pagemouseup'
 ];
+
 /**
  * @alias module:zrender/Handler
  * @constructor
@@ -50,7 +55,9 @@ var handlerNames = [
  * @param {HTMLElement} painterRoot painter.root (not painter.getViewportRoot()).
  */
 var Handler = function (storage, painter, proxy, painterRoot) {
-    Eventful.call(this);
+    Eventful.call(this, {
+        afterListenerChanged: util.bind(afterListenerChanged, null, this)
+    });
 
     this.storage = storage;
 
@@ -176,6 +183,10 @@ Handler.prototype = {
 
         !innerDom && this.trigger('globalout', {event: event});
     },
+
+    pagemousemove: util.curry(pageEventHandler, 'pagemousemove'),
+
+    pagemouseup: util.curry(pageEventHandler, 'pagemouseup'),
 
     /**
      * Resize
@@ -352,6 +363,10 @@ util.each(['click', 'mousedown', 'mouseup', 'mousewheel', 'dblclick', 'contextme
     };
 });
 
+function pageEventHandler(pageEventName, event) {
+    this.trigger(pageEventName, makeEventPacket(pageEventName, {}, event));
+}
+
 function isHover(displayable, x, y) {
     if (displayable[displayable.rectHover ? 'rectContain' : 'contain'](x, y)) {
         var el = displayable;
@@ -372,6 +387,13 @@ function isHover(displayable, x, y) {
     }
 
     return false;
+}
+
+function afterListenerChanged(handlerInstance) {
+    var listenerLen = countListener(handlerInstance, 'pagemousemove')
+        + countListener(handlerInstance, 'pagemouseup');
+    var proxy = handlerInstance.proxy;
+    proxy && proxy.enablePageEvent && proxy.enablePageEvent(!!listenerLen);
 }
 
 util.mixin(Handler, Eventful);

--- a/src/Handler.js
+++ b/src/Handler.js
@@ -6,7 +6,6 @@ import * as eventTool from './core/event';
 import GestureMgr from './core/GestureMgr';
 
 var SILENT = 'silent';
-var countListener = Eventful.countListener;
 
 function makeEventPacket(eveType, targetInfo, event) {
     return {
@@ -390,10 +389,10 @@ function isHover(displayable, x, y) {
 }
 
 function afterListenerChanged(handlerInstance) {
-    var listenerLen = countListener(handlerInstance, 'pagemousemove')
-        + countListener(handlerInstance, 'pagemouseup');
+    var allSilent = handlerInstance.isSilent('pagemousemove')
+        && handlerInstance.isSilent('pagemouseup');
     var proxy = handlerInstance.proxy;
-    proxy && proxy.enablePageEvent && proxy.enablePageEvent(!!listenerLen);
+    proxy && proxy.togglePageEvent && proxy.togglePageEvent(!allSilent);
 }
 
 util.mixin(Handler, Eventful);

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -168,6 +168,18 @@ function preparePointerTransformer(markers, saved) {
 }
 
 /**
+ * Find native event compat for legency IE.
+ * Should be called at the begining of a native event listener.
+ *
+ * @param {Event} [e] Mouse event or touch event or pointer event.
+ *        For lagency IE, we use `window.event` is used.
+ * @return {Event} The native event.
+ */
+export function getNativeEvent(e) {
+    return e || window.event;
+}
+
+/**
  * Normalize the coordinates of the input event.
  *
  * Get the `e.zrX` and `e.zrY`, which are relative to the top-left of
@@ -181,14 +193,14 @@ function preparePointerTransformer(markers, saved) {
  * between the result coords and the parameters `el` and `calculate`.
  *
  * @param {HTMLElement} el DOM element.
- * @param {Event} [e] Mouse event or touch event. For lagency IE,
- *        do not need to input it and `window.event` is used.
+ * @param {Event} [e] See `getNativeEvent`.
  * @param {boolean} [calculate=false] Whether to force calculate
  *        the coordinates but not use ones provided by browser.
+ * @return {UIEvent} The normalized native UIEvent.
  */
 export function normalizeEvent(el, e, calculate) {
 
-    e = e || window.event;
+    e = getNativeEvent(e);
 
     if (e.zrX != null) {
         return e;

--- a/src/dom/HandlerProxy.js
+++ b/src/dom/HandlerProxy.js
@@ -1,36 +1,106 @@
 
+/* global document */
+
 import {
     addEventListener,
     removeEventListener,
-    normalizeEvent
+    normalizeEvent,
+    getNativeEvent
 } from '../core/event';
 import * as zrUtil from '../core/util';
 import Eventful from '../mixin/Eventful';
 import env from '../core/env';
 
 var TOUCH_CLICK_DELAY = 300;
+// "page event" is defined in the comment of `[Page Event]`.
+var pageEventSupported = env.domSupported;
 
-var mouseHandlerNames = [
-    'click', 'dblclick', 'mousewheel', 'mouseout',
-    'mouseup', 'mousedown', 'mousemove', 'contextmenu'
-];
 
-var touchHandlerNames = [
-    'touchstart', 'touchend', 'touchmove'
-];
+/**
+ * [Page Event]
+ * "page events" are `pagemousemove` and `pagemouseup`.
+ * They are triggered when a user pointer interacts on the whole webpage
+ * rather than only inside the zrender area.
+ *
+ * The use case of page events can be, for example, if we are implementing a dragging feature:
+ * ```js
+ * zr.on('mousedown', function (event) {
+ *     var dragging = true;
+ *
+ *     // Listen to `pagemousemove` and `pagemouseup` rather than `mousemove` and `mouseup`,
+ *     // because `mousemove` and `mouseup` will not be triggered when the pointer is out
+ *     // of the zrender area.
+ *     zr.on('pagemousemove', handleMouseMove);
+ *     zr.on('pagemouseup', handleMouseUp);
+ *
+ *     function handleMouseMove(event) {
+ *         if (dragging) { ... }
+ *     }
+ *     function handleMouseUp(event) {
+ *         dragging = false; ...
+ *         zr.off('pagemousemove', handleMouseMove);
+ *         zr.off('pagemouseup', handleMouseUp);
+ *     }
+ * });
+ * ```
+ *
+ * [NOTICE]:
+ * (1) There are cases that `pagemousexxx` will not be triggered when the pointer is out of
+ * zrender area:
+ * "document.addEventListener" is not available in the current runtime environment,
+ * or there is any `stopPropagation` called at some user defined listeners on the ancestors
+ * of the zrender dom.
+ * (2) Although those bad cases exist, users do not need to worry about that. That is, if you
+ * listen to `pagemousexxx`, you do not need to listen to the correspoinding event `mousexxx`
+ * any more.
+ * Becuase inside zrender area, `pagemousexxx` will always be triggered, where they are
+ * triggered just after `mousexxx` triggered and sharing the same event object. Those bad
+ * cases only happen when the pointer is out of zrender area.
+ */
 
-var pointerEventNames = {
-    pointerdown: 1, pointerup: 1, pointermove: 1, pointerout: 1
+
+var localNativeListenerNames = (function () {
+    var mouseHandlerNames = [
+        'click', 'dblclick', 'mousewheel', 'mouseout',
+        'mouseup', 'mousedown', 'mousemove', 'contextmenu'
+    ];
+    var touchHandlerNames = [
+        'touchstart', 'touchend', 'touchmove'
+    ];
+    var pointerEventNameMap = {
+        pointerdown: 1, pointerup: 1, pointermove: 1, pointerout: 1
+    };
+    var pointerHandlerNames = zrUtil.map(mouseHandlerNames, function (name) {
+        var nm = name.replace('mouse', 'pointer');
+        return pointerEventNameMap.hasOwnProperty(nm) ? nm : name;
+    });
+
+    return {
+        mouse: mouseHandlerNames,
+        touch: touchHandlerNames,
+        pointer: pointerHandlerNames
+    };
+})();
+
+var globalNativeListenerNames = {
+    mouse: ['mousemove', 'mouseup'],
+    touch: ['touchmove', 'touchend'],
+    pointer: ['pointermove', 'pointerup']
 };
 
-var pointerHandlerNames = zrUtil.map(mouseHandlerNames, function (name) {
-    var nm = name.replace('mouse', 'pointer');
-    return pointerEventNames[nm] ? nm : name;
-});
 
 function eventNameFix(name) {
     return (name === 'mousewheel' && env.browser.firefox) ? 'DOMMouseScroll' : name;
 }
+
+function isPointerFromTouch(event) {
+    var pointerType = event.pointerType;
+    return pointerType === 'pen' || pointerType === 'touch';
+}
+
+// function useMSGuesture(handlerProxy, event) {
+//     return isPointerFromTouch(event) && !!handlerProxy._msGesture;
+// }
 
 // function onMSGestureChange(proxy, event) {
 //     if (event.translationX || event.translationY) {
@@ -51,33 +121,46 @@ function eventNameFix(name) {
  * 1. Mobile browsers dispatch mouse events 300ms after touchend.
  * 2. Chrome for Android dispatch mousedown for long-touch about 650ms
  * Result: Blocking Mouse Events for 700ms.
+ *
+ * @param {DOMHandlerScope} scope
  */
-function setTouchTimer(instance) {
-    instance._touching = true;
-    clearTimeout(instance._touchTimer);
-    instance._touchTimer = setTimeout(function () {
-        instance._touching = false;
+function setTouchTimer(scope) {
+    scope.touching = true;
+    if (scope.touchTimer != null) {
+        clearTimeout(scope.touchTimer);
+        scope.touchTimer = null;
+    }
+    scope.touchTimer = setTimeout(function () {
+        scope.touching = false;
+        scope.touchTimer = null;
     }, 700);
 }
 
+function markTriggeredFromLocal(event) {
+    event && (event.zrIsFromLocal = true);
+}
 
-var domHandlers = {
-    /**
-     * Mouse move handler
-     * @inner
-     * @param {Event} event
-     */
-    mousemove: function (event) {
-        event = normalizeEvent(this.dom, event);
+function isTriggeredFromLocal(event) {
+    return !!(event && event.zrIsFromLocal);
+}
 
-        this.trigger('mousemove', event);
-    },
+// Mark touch, which is useful in distinguish touch and
+// mouse event in upper applicatoin.
+function markTouch(event) {
+    event && (event.zrByTouch = true);
+}
 
-    /**
-     * Mouse out handler
-     * @inner
-     * @param {Event} event
-     */
+
+// ----------------------------
+// Native event handlers BEGIN
+// ----------------------------
+
+/**
+ * Local DOM Handlers
+ * @this {HandlerProxy}
+ */
+var localDOMHandlers = {
+
     mouseout: function (event) {
         event = normalizeEvent(this.dom, event);
 
@@ -96,72 +179,46 @@ var domHandlers = {
         this.trigger('mouseout', event);
     },
 
-    /**
-     * Touch开始响应函数
-     * @inner
-     * @param {Event} event
-     */
     touchstart: function (event) {
         // Default mouse behaviour should not be disabled here.
         // For example, page may needs to be slided.
         event = normalizeEvent(this.dom, event);
 
-        // Mark touch, which is useful in distinguish touch and
-        // mouse event in upper applicatoin.
-        event.zrByTouch = true;
+        markTouch(event);
 
         this._lastTouchMoment = new Date();
 
         this.handler.processGesture(event, 'start');
 
-        // In touch device, trigger `mousemove`(`mouseover`) should
-        // be triggered, and must before `mousedown` triggered.
-        domHandlers.mousemove.call(this, event);
-
-        domHandlers.mousedown.call(this, event);
-
-        setTouchTimer(this);
+        // For consistent event listener for both touch device and mouse device,
+        // we simulate "mouseover-->mousedown" in touch device. So we trigger
+        // `mousemove` here (to trigger `mouseover` inside), and then trigger
+        // `mousedown`.
+        localDOMHandlers.mousemove.call(this, event);
+        localDOMHandlers.mousedown.call(this, event);
     },
 
-    /**
-     * Touch移动响应函数
-     * @inner
-     * @param {Event} event
-     */
     touchmove: function (event) {
-
         event = normalizeEvent(this.dom, event);
 
-        // Mark touch, which is useful in distinguish touch and
-        // mouse event in upper applicatoin.
-        event.zrByTouch = true;
+        markTouch(event);
 
         this.handler.processGesture(event, 'change');
 
         // Mouse move should always be triggered no matter whether
         // there is gestrue event, because mouse move and pinch may
         // be used at the same time.
-        domHandlers.mousemove.call(this, event);
-
-        setTouchTimer(this);
+        localDOMHandlers.mousemove.call(this, event);
     },
 
-    /**
-     * Touch结束响应函数
-     * @inner
-     * @param {Event} event
-     */
     touchend: function (event) {
-
         event = normalizeEvent(this.dom, event);
 
-        // Mark touch, which is useful in distinguish touch and
-        // mouse event in upper applicatoin.
-        event.zrByTouch = true;
+        markTouch(event);
 
         this.handler.processGesture(event, 'end');
 
-        domHandlers.mouseup.call(this, event);
+        localDOMHandlers.mouseup.call(this, event);
 
         // Do not trigger `mouseout` here, in spite of `mousemove`(`mouseover`) is
         // triggered in `touchstart`. This seems to be illogical, but by this mechanism,
@@ -174,14 +231,12 @@ var domHandlers = {
         // click event should always be triggered no matter whether
         // there is gestrue event. System click can not be prevented.
         if (+new Date() - this._lastTouchMoment < TOUCH_CLICK_DELAY) {
-            domHandlers.click.call(this, event);
+            localDOMHandlers.click.call(this, event);
         }
-
-        setTouchTimer(this);
     },
 
     pointerdown: function (event) {
-        domHandlers.mousedown.call(this, event);
+        localDOMHandlers.mousedown.call(this, event);
 
         // if (useMSGuesture(this, event)) {
         //     this._msGesture.addPointer(event.pointerId);
@@ -195,12 +250,12 @@ var domHandlers = {
         // upper application. So, we dont support mousemove on MS touch
         // device yet.
         if (!isPointerFromTouch(event)) {
-            domHandlers.mousemove.call(this, event);
+            localDOMHandlers.mousemove.call(this, event);
         }
     },
 
     pointerup: function (event) {
-        domHandlers.mouseup.call(this, event);
+        localDOMHandlers.mouseup.call(this, event);
     },
 
     pointerout: function (event) {
@@ -208,82 +263,88 @@ var domHandlers = {
         // (IE11+/Edge on MS Surface) after click event triggered,
         // which is inconsistent with the mousout behavior we defined
         // in touchend. So we unify them.
-        // (check domHandlers.touchend for detailed explanation)
+        // (check localDOMHandlers.touchend for detailed explanation)
         if (!isPointerFromTouch(event)) {
-            domHandlers.mouseout.call(this, event);
+            localDOMHandlers.mouseout.call(this, event);
         }
     }
+
 };
 
-function isPointerFromTouch(event) {
-    var pointerType = event.pointerType;
-    return pointerType === 'pen' || pointerType === 'touch';
-}
-
-// function useMSGuesture(handlerProxy, event) {
-//     return isPointerFromTouch(event) && !!handlerProxy._msGesture;
-// }
-
-// Common handlers
-zrUtil.each(['click', 'mousedown', 'mouseup', 'mousewheel', 'dblclick', 'contextmenu'], function (name) {
-    domHandlers[name] = function (event) {
+/**
+ * Othere DOM UI Event handlers for zr dom.
+ * @this {HandlerProxy}
+ */
+zrUtil.each(['click', 'mousemove', 'mousedown', 'mouseup', 'mousewheel', 'dblclick', 'contextmenu'], function (name) {
+    localDOMHandlers[name] = function (event) {
         event = normalizeEvent(this.dom, event);
         this.trigger(name, event);
+
+        if (name === 'mousemove' || name === 'mouseup') {
+            // Trigger `pagemousexxx` immediately with the same event object.
+            // See the reason described in the comment of `[Page Event]`.
+            this.trigger('page' + name, event);
+        }
     };
 });
 
+
 /**
- * 为控制类实例初始化dom 事件处理函数
- *
- * @inner
- * @param {module:zrender/Handler} instance 控制类实例
+ * Page DOM UI Event handlers for global page.
+ * @this {HandlerProxy}
  */
-function initDomHandler(instance) {
-    zrUtil.each(touchHandlerNames, function (name) {
-        instance._handlers[name] = zrUtil.bind(domHandlers[name], instance);
-    });
+var globalDOMHandlers = {
 
-    zrUtil.each(pointerHandlerNames, function (name) {
-        instance._handlers[name] = zrUtil.bind(domHandlers[name], instance);
-    });
+    touchmove: function (event) {
+        markTouch(event);
+        globalDOMHandlers.mousemove.call(this, event);
+    },
 
-    zrUtil.each(mouseHandlerNames, function (name) {
-        instance._handlers[name] = makeMouseHandler(domHandlers[name], instance);
-    });
+    touchend: function (event) {
+        markTouch(event);
+        globalDOMHandlers.mouseup.call(this, event);
+    },
 
-    function makeMouseHandler(fn, instance) {
-        return function () {
-            if (instance._touching) {
-                return;
-            }
-            return fn.apply(instance, arguments);
-        };
+    pointermove: function (event) {
+        // FIXME
+        // pointermove is so sensitive that it always triggered when
+        // tap(click) on touch screen, which affect some judgement in
+        // upper application. So, we dont support mousemove on MS touch
+        // device yet.
+        if (!isPointerFromTouch(event)) {
+            globalDOMHandlers.mousemove.call(this, event);
+        }
+    },
+
+    pointerup: function (event) {
+        globalDOMHandlers.mouseup.call(this, event);
+    },
+
+    mousemove: function (event) {
+        event = normalizeEvent(this.dom, event, true);
+        this.trigger('pagemousemove', event);
+    },
+
+    mouseup: function (event) {
+        event = normalizeEvent(this.dom, event, true);
+        this.trigger('pagemouseup', event);
     }
-}
+};
+
+// ----------------------------
+// Native event handlers END
+// ----------------------------
 
 
-function HandlerDomProxy(dom) {
-    Eventful.call(this);
-
-    this.dom = dom;
-
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this._touching = false;
-
-    /**
-     * @private
-     * @type {number}
-     */
-    this._touchTimer;
-
-    this._handlers = {};
-
-    this._mountedHandlerNames = [];
-
-    initDomHandler(this);
+/**
+ * @param {HandlerProxy} instance
+ * @param {DOMHandlerScope} scope
+ * @param {Object} nativeListenerNames {mouse: Array<string>, touch: Array<string>, poiner: Array<string>}
+ * @param {boolean} localOrGlobal `true`: target local, `false`: target global.
+ */
+function mountDOMEventListeners(instance, scope, nativeListenerNames, localOrGlobal) {
+    var domHandlers = scope.domHandlers;
+    var domTarget = scope.domTarget;
 
     if (env.pointerEventsSupported) { // Only IE11+/Edge
         // 1. On devices that both enable touch and mouse (e.g., MS Surface and lenovo X240),
@@ -292,7 +353,14 @@ function HandlerDomProxy(dom) {
         // 2. On MS Surface, it probablely only trigger mousedown but no mouseup when tap on
         // screen, which do not occurs in pointer event.
         // So we use pointer event to both detect touch gesture and mouse behavior.
-        mountHandlers(pointerHandlerNames, this);
+        zrUtil.each(nativeListenerNames.pointer, function (nativeEventName) {
+            mountSingle(nativeEventName, function (event) {
+                if (localOrGlobal || !isTriggeredFromLocal(event)) {
+                    localOrGlobal && markTriggeredFromLocal(event);
+                    domHandlers[nativeEventName].call(instance, event);
+                }
+            });
+        });
 
         // FIXME
         // Note: MS Gesture require CSS touch-action set. But touch-action is not reliable,
@@ -311,7 +379,15 @@ function HandlerDomProxy(dom) {
     }
     else {
         if (env.touchEventsSupported) {
-            mountHandlers(touchHandlerNames, this);
+            zrUtil.each(nativeListenerNames.touch, function (nativeEventName) {
+                mountSingle(nativeEventName, function (event) {
+                    if (localOrGlobal || !isTriggeredFromLocal(event)) {
+                        localOrGlobal && markTriggeredFromLocal(event);
+                        domHandlers[nativeEventName].call(instance, event);
+                        setTouchTimer(scope);
+                    }
+                });
+            });
             // Handler of 'mouseout' event is needed in touch mode, which will be mounted below.
             // addEventListener(root, 'mouseout', this._mouseoutHandler);
         }
@@ -321,29 +397,100 @@ function HandlerDomProxy(dom) {
         // mouse event can not be handle in those devices.
         // 2. On MS Surface, Chrome will trigger both touch event and mouse event. How to prevent
         // mouseevent after touch event triggered, see `setTouchTimer`.
-        mountHandlers(mouseHandlerNames, this);
+        zrUtil.each(nativeListenerNames.mouse, function (nativeEventName) {
+            mountSingle(nativeEventName, function (event) {
+                event = getNativeEvent(event);
+                if (!scope.touching
+                    && (localOrGlobal || !isTriggeredFromLocal(event))
+                ) {
+                    localOrGlobal && markTriggeredFromLocal(event);
+                    domHandlers[nativeEventName].call(instance, event);
+                }
+            });
+        });
     }
 
-    function mountHandlers(handlerNames, instance) {
-        zrUtil.each(handlerNames, function (name) {
-            addEventListener(dom, eventNameFix(name), instance._handlers[name]);
-            instance._mountedHandlerNames.push(name);
-        }, instance);
+    function mountSingle(nativeEventName, listener) {
+        scope.mounted[nativeEventName] = listener;
+        addEventListener(domTarget, eventNameFix(nativeEventName), listener);
     }
 }
 
-var handlerDomProxyProto = HandlerDomProxy.prototype;
-handlerDomProxyProto.dispose = function () {
-    var handlerNames = this._mountedHandlerNames;
+function unmountDOMEventListeners(scope) {
+    var mounted = scope.mounted;
+    for (var nativeEventName in mounted) {
+        if (mounted.hasOwnProperty(nativeEventName)) {
+            removeEventListener(scope.domTarget, eventNameFix(nativeEventName), mounted[nativeEventName]);
+        }
+    }
+    scope.mounted = {};
+}
 
-    for (var i = 0; i < handlerNames.length; i++) {
-        var name = handlerNames[i];
-        removeEventListener(this.dom, eventNameFix(name), this._handlers[name]);
+
+/**
+ * @inner
+ * @class
+ */
+function DOMHandlerScope(domTarget, domHandlers) {
+    this.domTarget = domTarget;
+    this.domHandlers = domHandlers;
+
+    // Key: eventName, value: mounted handler funcitons.
+    // Used for unmount.
+    this.mounted = {};
+
+    this.touchTimer = null;
+    this.touching = false;
+}
+
+/**
+ * @public
+ * @class
+ */
+function HandlerDomProxy(dom) {
+    Eventful.call(this);
+
+    this.dom = dom;
+
+    this._localHandlerScope = new DOMHandlerScope(dom, localDOMHandlers);
+
+    if (pageEventSupported) {
+        this._globalHandlerScope = new DOMHandlerScope(document, globalDOMHandlers);
+    }
+
+    this._pageEventEnabled = false;
+
+    mountDOMEventListeners(this, this._localHandlerScope, localNativeListenerNames, true);
+}
+
+var handlerDomProxyProto = HandlerDomProxy.prototype;
+
+handlerDomProxyProto.dispose = function () {
+    unmountDOMEventListeners(this._localHandlerScope);
+    if (pageEventSupported) {
+        unmountDOMEventListeners(this._globalHandlerScope);
     }
 };
 
 handlerDomProxyProto.setCursor = function (cursorStyle) {
     this.dom.style && (this.dom.style.cursor = cursorStyle || 'default');
+};
+
+/**
+ * The implementation of page event depends on listening to document.
+ * So we should better only listen to that on needed, and remove the
+ * listeners when do not need them to escape unexpected side-effect.
+ * @param {boolean} enableOrDisable `true`: enable page event. `false`: disable page event.
+ */
+handlerDomProxyProto.enablePageEvent = function (enableOrDisable) {
+    if (pageEventSupported && (this._pageEventEnabled ^ enableOrDisable)) {
+        this._pageEventEnabled = enableOrDisable;
+
+        var globalHandlerScope = this._globalHandlerScope;
+        enableOrDisable
+            ? mountDOMEventListeners(this, globalHandlerScope, globalNativeListenerNames)
+            : unmountDOMEventListeners(globalHandlerScope);
+    }
 };
 
 zrUtil.mixin(HandlerDomProxy, Eventful);

--- a/src/dom/HandlerProxy.js
+++ b/src/dom/HandlerProxy.js
@@ -281,6 +281,8 @@ function HandlerDomProxy(dom) {
 
     this._handlers = {};
 
+    this._mountedHandlerNames = [];
+
     initDomHandler(this);
 
     if (env.pointerEventsSupported) { // Only IE11+/Edge
@@ -325,13 +327,14 @@ function HandlerDomProxy(dom) {
     function mountHandlers(handlerNames, instance) {
         zrUtil.each(handlerNames, function (name) {
             addEventListener(dom, eventNameFix(name), instance._handlers[name]);
+            instance._mountedHandlerNames.push(name);
         }, instance);
     }
 }
 
 var handlerDomProxyProto = HandlerDomProxy.prototype;
 handlerDomProxyProto.dispose = function () {
-    var handlerNames = mouseHandlerNames.concat(touchHandlerNames);
+    var handlerNames = this._mountedHandlerNames;
 
     for (var i = 0; i < handlerNames.length; i++) {
         var name = handlerNames[i];

--- a/src/dom/HandlerProxy.js
+++ b/src/dom/HandlerProxy.js
@@ -482,7 +482,9 @@ handlerDomProxyProto.setCursor = function (cursorStyle) {
  * listeners when do not need them to escape unexpected side-effect.
  * @param {boolean} enableOrDisable `true`: enable page event. `false`: disable page event.
  */
-handlerDomProxyProto.enablePageEvent = function (enableOrDisable) {
+handlerDomProxyProto.togglePageEvent = function (enableOrDisable) {
+    zrUtil.assert(enableOrDisable != null);
+
     if (pageEventSupported && (this._pageEventEnabled ^ enableOrDisable)) {
         this._pageEventEnabled = enableOrDisable;
 

--- a/src/mixin/Draggable.js
+++ b/src/mixin/Draggable.js
@@ -3,9 +3,10 @@
 function Draggable() {
 
     this.on('mousedown', this._dragStart, this);
-    this.on('mousemove', this._drag, this);
-    this.on('mouseup', this._dragEnd, this);
-    this.on('globalout', this._dragEnd, this);
+    // this.on('mousemove', this._drag, this);
+    // this.on('mouseup', this._dragEnd, this);
+    // this.on('globalout', this._dragEnd, this);
+
     // this._dropTarget = null;
     // this._draggingTarget = null;
 
@@ -24,6 +25,9 @@ Draggable.prototype = {
             draggingTarget.dragging = true;
             this._x = e.offsetX;
             this._y = e.offsetY;
+
+            this.on('pagemousemove', this._drag, this);
+            this.on('pagemouseup', this._dragEnd, this);
 
             this.dispatchToElement(param(draggingTarget, e), 'dragstart', e.event);
         }
@@ -65,6 +69,9 @@ Draggable.prototype = {
         if (draggingTarget) {
             draggingTarget.dragging = false;
         }
+
+        this.off('pagemousemove', this._drag);
+        this.off('pagemouseup', this._dragEnd);
 
         this.dispatchToElement(param(draggingTarget, e), 'dragend', e.event);
 

--- a/src/mixin/Eventful.js
+++ b/src/mixin/Eventful.js
@@ -238,25 +238,6 @@ Eventful.prototype = {
 };
 
 
-// -----------------------------------------------------------------------
-// [Static Inner Methods]
-// These APIs can not be mounted to `Eventful` class, becuase `Eventful`
-// is a widely-used mixin, where adding new API might has name conflict
-// issue. So we expose these APIs as static methods.
-// -----------------------------------------------------------------------
-
-/**
- * Count listeners of the given `eventType`.
- * @param {Eventful} eventful
- * @param {string} eventType
- * @return {number} The number of the event listeners.
- */
-Eventful.countListener = function (eventful, eventType) {
-    var _h = eventful._$handlers[eventType];
-    return _h ? _h.length : 0;
-};
-
-
 function callListenerChanged(eventful, eventType) {
     var eventProcessor = eventful._$eventProcessor;
     if (eventProcessor && eventProcessor.afterListenerChanged) {


### PR DESCRIPTION
 [Page Event]
 "page events" are `pagemousemove` and `pagemouseup`.
 They are triggered when a user pointer interacts on the whole webpage
 rather than only inside the zrender area.

 The use case of page events can be, for example, if we are implementing a dragging feature:
 ```js
 zr.on('mousedown', function (event) {
     var dragging = true;

     // Listen to `pagemousemove` and `pagemouseup` rather than `mousemove` and `mouseup`,
     // because `mousemove` and `mouseup` will not be triggered when the pointer is out
     // of the zrender area.
     zr.on('pagemousemove', handleMouseMove);
     zr.on('pagemouseup', handleMouseUp);

     function handleMouseMove(event) {
         if (dragging) { ... }
     }
     function handleMouseUp(event) {
         dragging = false; ...
         zr.off('pagemousemove', handleMouseMove);
         zr.off('pagemouseup', handleMouseUp);
     }
 });
 ```

 [NOTICE]:
 (1) There are cases that `pagemousexxx` will not be triggered when the pointer is out of
 zrender area:
 "document.addEventListener" is not available in the current runtime environment,
 or there is any `stopPropagation` called at some user defined listeners on the ancestors
 of the zrender dom.
 (2) Although those bad cases exist, users do not need to worry about that. That is, if you
 listen to `pagemousexxx`, you do not need to listen to the correspoinding event `mousexxx`
 any more.
 Becuase inside zrender area, `pagemousexxx` will always be triggered, where they are
 triggered just after `mousexxx` triggered and sharing the same event object. Those bad
 cases only happen when the pointer is out of zrender area.

Check <https://github.com/apache/incubator-echarts/pull/11710/files#diff-bcd811d4d43d3bc2cfccb7e76aeb0354>