### PR TITLE
fix(svg): fix removing el may have error when text is set to none

### DIFF
--- a/src/svg/graphic.js
+++ b/src/svg/graphic.js
@@ -512,7 +512,10 @@ function updateTextLocation(tspan, textAlign, x, y) {
 
 function removeOldTextNode(el) {
     if (el && el.__textSvgEl) {
-        el.__textSvgEl.parentNode.removeChild(el.__textSvgEl);
+        // textSvgEl may has no parentNode if el has been removed temporary.
+        if (el.__textSvgEl.parentNode) {
+            el.__textSvgEl.parentNode.removeChild(el.__textSvgEl);
+        }
         el.__textSvgEl = null;
         el.__tspanList = [];
         el.__text = null;


### PR DESCRIPTION
The parentNode in https://github.com/ecomfe/zrender/pull/542/files#diff-5bb01bd8925bd801f17e33bdb859d019R516 may be null if the element is removed in https://github.com/ecomfe/zrender/blob/svg-fix-text-remove-error/src/svg/Painter.js#L205