### PR TITLE
enhancement of mouse event in dragging.

### DIFF
--- a/src/core/env.js
+++ b/src/core/env.js
@@ -148,12 +148,17 @@ function detect(ua) {
         // default, so we dont check navigator.maxTouchPoints for them here.
         touchEventsSupported: 'ontouchstart' in window && !browser.ie && !browser.edge,
         // <http://caniuse.com/#search=pointer%20event>.
-        pointerEventsSupported: 'onpointerdown' in window
-            // Firefox supports pointer but not by default, only MS browsers are reliable on pointer
+        pointerEventsSupported:
+            // (1) Firefox supports pointer but not by default, only MS browsers are reliable on pointer
             // events currently. So we dont use that on other browsers unless tested sufficiently.
-            // Although IE 10 supports pointer event, it use old style and is different from the
+            // For example, in iOS 13 Mobile Chromium 78, if the touching behavior starts page
+            // scroll, the `pointermove` event can not be fired any more. That will break some
+            // features like "pan horizontally to move something and pan vertically to page scroll".
+            // The horizontal pan probably be interrupted by the casually triggered page scroll.
+            // (2) Although IE 10 supports pointer event, it use old style and is different from the
             // standard. So we exclude that. (IE 10 is hardly used on touch device)
-            && (browser.edge || (browser.ie && browser.version >= 11)),
+            'onpointerdown' in window
+                && (browser.edge || (browser.ie && browser.version >= 11)),
         // passiveSupported: detectPassiveSupport()
         domSupported: typeof document !== 'undefined'
     };

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -240,8 +240,11 @@ export function normalizeEvent(el, e, calculate) {
  * @param {HTMLElement} el
  * @param {string} name
  * @param {Function} handler
+ * @param {Object|boolean} opt If boolean, means `opt.capture`
+ * @param {boolean} [opt.capture=false]
+ * @param {boolean} [opt.passive=false]
  */
-export function addEventListener(el, name, handler) {
+export function addEventListener(el, name, handler, opt) {
     if (isDomLevel2) {
         // Reproduct the console warning:
         // [Violation] Added non-passive event listener to a scroll-blocking <some> event.
@@ -264,21 +267,6 @@ export function addEventListener(el, name, handler) {
         //     // By default, the third param of el.addEventListener is `capture: false`.
         //     : void 0;
         // el.addEventListener(name, handler /* , opts */);
-        el.addEventListener(name, handler);
-    }
-    else {
-        el.attachEvent('on' + name, handler);
-    }
-}
-
-/**
- * Do not modify the originally `addEventListener` method above becuase
- * being worried about some users have been calling the `addEventListener`
- * with extra parameters (e.g., in some callback of Array map/each).
- * The extra parameters might used as `useCapture` unexpectedly.
- */
-export function addEventListener2(el, name, handler, opt) {
-    if (isDomLevel2) {
         el.addEventListener(name, handler, opt);
     }
     else {
@@ -287,17 +275,14 @@ export function addEventListener2(el, name, handler, opt) {
     }
 }
 
-export function removeEventListener(el, name, handler) {
-    if (isDomLevel2) {
-        el.removeEventListener(name, handler);
-    }
-    else {
-        el.detachEvent('on' + name, handler);
-    }
-}
-
-// See `addEventListener2`
-export function removeEventListener2(el, name, handler, opt) {
+/**
+ * Parameter are the same as `addEventListener`.
+ *
+ * Notice that if a listener is registered twice, one with capture and one without,
+ * remove each one separately. Removal of a capturing listener does not affect a
+ * non-capturing version of the same listener, and vice versa.
+ */
+export function removeEventListener(el, name, handler, opt) {
     if (isDomLevel2) {
         el.removeEventListener(name, handler, opt);
     }

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -271,9 +271,35 @@ export function addEventListener(el, name, handler) {
     }
 }
 
+/**
+ * Do not modify the originally `addEventListener` method above becuase
+ * being worried about some users have been calling the `addEventListener`
+ * with extra parameters (e.g., in some callback of Array map/each).
+ * The extra parameters might used as `useCapture` unexpectedly.
+ */
+export function addEventListener2(el, name, handler, opt) {
+    if (isDomLevel2) {
+        el.addEventListener(name, handler, opt);
+    }
+    else {
+        // For simplicity, do not implement `setCapture` for IE9-.
+        el.attachEvent('on' + name, handler);
+    }
+}
+
 export function removeEventListener(el, name, handler) {
     if (isDomLevel2) {
         el.removeEventListener(name, handler);
+    }
+    else {
+        el.detachEvent('on' + name, handler);
+    }
+}
+
+// See `addEventListener2`
+export function removeEventListener2(el, name, handler, opt) {
+    if (isDomLevel2) {
+        el.removeEventListener(name, handler, opt);
     }
     else {
         el.detachEvent('on' + name, handler);

--- a/src/dom/HandlerProxy.js
+++ b/src/dom/HandlerProxy.js
@@ -2,8 +2,8 @@
 /* global document */
 
 import {
-    addEventListener2,
-    removeEventListener2,
+    addEventListener,
+    removeEventListener,
     normalizeEvent,
     getNativeEvent
 } from '../core/event';
@@ -460,14 +460,14 @@ function mountGlobalDOMEventListeners(instance, scope) {
 function mountSingleDOMEventListener(scope, nativeEventName, listener, opt) {
     scope.mounted[nativeEventName] = listener;
     scope.listenerOpts[nativeEventName] = opt;
-    addEventListener2(scope.domTarget, eventNameFix(nativeEventName), listener, opt);
+    addEventListener(scope.domTarget, eventNameFix(nativeEventName), listener, opt);
 }
 
 function unmountDOMEventListeners(scope) {
     var mounted = scope.mounted;
     for (var nativeEventName in mounted) {
         if (mounted.hasOwnProperty(nativeEventName)) {
-            removeEventListener2(
+            removeEventListener(
                 scope.domTarget, eventNameFix(nativeEventName), mounted[nativeEventName],
                 scope.listenerOpts[nativeEventName]
             );

--- a/src/dom/HandlerProxy.js
+++ b/src/dom/HandlerProxy.js
@@ -2,8 +2,8 @@
 /* global document */
 
 import {
-    addEventListener,
-    removeEventListener,
+    addEventListener2,
+    removeEventListener2,
     normalizeEvent,
     getNativeEvent
 } from '../core/event';
@@ -12,51 +12,8 @@ import Eventful from '../mixin/Eventful';
 import env from '../core/env';
 
 var TOUCH_CLICK_DELAY = 300;
-// "page event" is defined in the comment of `[Page Event]`.
-var pageEventSupported = env.domSupported;
 
-
-/**
- * [Page Event]
- * "page events" are `pagemousemove` and `pagemouseup`.
- * They are triggered when a user pointer interacts on the whole webpage
- * rather than only inside the zrender area.
- *
- * The use case of page events can be, for example, if we are implementing a dragging feature:
- * ```js
- * zr.on('mousedown', function (event) {
- *     var dragging = true;
- *
- *     // Listen to `pagemousemove` and `pagemouseup` rather than `mousemove` and `mouseup`,
- *     // because `mousemove` and `mouseup` will not be triggered when the pointer is out
- *     // of the zrender area.
- *     zr.on('pagemousemove', handleMouseMove);
- *     zr.on('pagemouseup', handleMouseUp);
- *
- *     function handleMouseMove(event) {
- *         if (dragging) { ... }
- *     }
- *     function handleMouseUp(event) {
- *         dragging = false; ...
- *         zr.off('pagemousemove', handleMouseMove);
- *         zr.off('pagemouseup', handleMouseUp);
- *     }
- * });
- * ```
- *
- * [NOTICE]:
- * (1) There are cases that `pagemousexxx` will not be triggered when the pointer is out of
- * zrender area:
- * "document.addEventListener" is not available in the current runtime environment,
- * or there is any `stopPropagation` called at some user defined listeners on the ancestors
- * of the zrender dom.
- * (2) Although those bad cases exist, users do not need to worry about that. That is, if you
- * listen to `pagemousexxx`, you do not need to listen to the correspoinding event `mousexxx`
- * any more.
- * Becuase inside zrender area, `pagemousexxx` will always be triggered, where they are
- * triggered just after `mousexxx` triggered and sharing the same event object. Those bad
- * cases only happen when the pointer is out of zrender area.
- */
+var globalEventSupported = env.domSupported;
 
 
 var localNativeListenerNames = (function () {
@@ -84,7 +41,6 @@ var localNativeListenerNames = (function () {
 
 var globalNativeListenerNames = {
     mouse: ['mousemove', 'mouseup'],
-    touch: ['touchmove', 'touchend'],
     pointer: ['pointermove', 'pointerup']
 };
 
@@ -136,14 +92,6 @@ function setTouchTimer(scope) {
     }, 700);
 }
 
-function markTriggeredFromLocal(event) {
-    event && (event.zrIsFromLocal = true);
-}
-
-function isTriggeredFromLocal(event) {
-    return !!(event && event.zrIsFromLocal);
-}
-
 // Mark touch, which is useful in distinguish touch and
 // mouse event in upper applicatoin.
 function markTouch(event) {
@@ -151,9 +99,58 @@ function markTouch(event) {
 }
 
 
-// ----------------------------
-// Native event handlers BEGIN
-// ----------------------------
+// function markTriggeredFromLocal(event) {
+//     event && (event.__zrIsFromLocal = true);
+// }
+
+// function isTriggeredFromLocal(instance, event) {
+//     return !!(event && event.__zrIsFromLocal);
+// }
+
+function normalizeGlobalEvent(instance, event) {
+    // offsetX, offsetY still need to be calculated. They are necessary in the event
+    // handlers of the upper applications. Set `true` to force calculate them.
+    return normalizeEvent(instance.dom, new FakeGlobalEvent(instance, event), true);
+}
+
+/**
+ * Detect whether the given el is in `painterRoot`.
+ */
+function isLocalEl(instance, el) {
+    var isLocal = false;
+    do {
+        el = el && el.parentNode;
+    }
+    while (el && el.nodeType !== 9 && !(
+        isLocal = el === instance.painterRoot
+    ));
+    return isLocal;
+}
+
+/**
+ * Make a fake event but not change the original event,
+ * becuase the global event probably be used by other
+ * listeners not belonging to zrender.
+ * @class
+ */
+function FakeGlobalEvent(instance, event) {
+    this.type = event.type;
+    this.target = this.currentTarget = instance.dom;
+    this.pointerType = event.pointerType;
+    // Necessray for the force calculation of zrX, zrY
+    this.clientX = event.clientX;
+    this.clientY = event.clientY;
+    // Because we do not mount global listeners to touch events,
+    // we do not copy `targetTouches` and `changedTouches` here.
+}
+var fakeGlobalEventProto = FakeGlobalEvent.prototype;
+// we make the default methods on the event do nothing,
+// otherwise it is dangerous. See more details in
+// [Drag outside] in `Handler.js`.
+fakeGlobalEventProto.stopPropagation =
+    fakeGlobalEventProto.stopImmediatePropagation =
+    fakeGlobalEventProto.preventDefault = zrUtil.noop;
+
 
 /**
  * Local DOM Handlers
@@ -161,20 +158,49 @@ function markTouch(event) {
  */
 var localDOMHandlers = {
 
+    mousedown: function (event) {
+        event = normalizeEvent(this.dom, event);
+
+        this._mayPointerCapture = [event.zrX, event.zrY];
+
+        this.trigger('mousedown', event);
+    },
+
+    mousemove: function (event) {
+        event = normalizeEvent(this.dom, event);
+
+        var downPoint = this._mayPointerCapture;
+        if (downPoint && (event.zrX !== downPoint[0] || event.zrY !== downPoint[1])) {
+            togglePointerCapture(this, true);
+        }
+
+        this.trigger('mousemove', event);
+    },
+
+    mouseup: function (event) {
+        event = normalizeEvent(this.dom, event);
+
+        togglePointerCapture(this, false);
+
+        this.trigger('mouseup', event);
+    },
+
     mouseout: function (event) {
         event = normalizeEvent(this.dom, event);
 
-        var element = event.toElement || event.relatedTarget;
-        if (element !== this.dom) {
-            while (element && element.nodeType !== 9) {
-                // 忽略包含在root中的dom引起的mouseOut
-                if (element === this.dom) {
-                    return;
-                }
-
-                element = element.parentNode;
-            }
+        // Similarly to the browser did on `document` and touch event,
+        // `globalout` will be delayed to final pointer cature release.
+        if (this._pointerCapturing) {
+            event.zrEventControl = 'no_globalout';
         }
+
+        // There might be some doms created by upper layer application
+        // at the same level of painter.getViewportRoot() (e.g., tooltip
+        // dom created by echarts), where 'globalout' event should not
+        // be triggered when mouse enters these doms. (But 'mouseout'
+        // should be triggered at the original hovered element as usual).
+        var element = event.toElement || event.relatedTarget;
+        event.zrIsToLocalDOM = isLocalEl(this, element);
 
         this.trigger('mouseout', event);
     },
@@ -275,35 +301,23 @@ var localDOMHandlers = {
  * Othere DOM UI Event handlers for zr dom.
  * @this {HandlerProxy}
  */
-zrUtil.each(['click', 'mousemove', 'mousedown', 'mouseup', 'mousewheel', 'dblclick', 'contextmenu'], function (name) {
+zrUtil.each(['click', 'mousewheel', 'dblclick', 'contextmenu'], function (name) {
     localDOMHandlers[name] = function (event) {
         event = normalizeEvent(this.dom, event);
         this.trigger(name, event);
-
-        if (name === 'mousemove' || name === 'mouseup') {
-            // Trigger `pagemousexxx` immediately with the same event object.
-            // See the reason described in the comment of `[Page Event]`.
-            this.trigger('page' + name, event);
-        }
     };
 });
 
 
 /**
- * Page DOM UI Event handlers for global page.
+ * DOM UI Event handlers for global page.
+ *
+ * [Caution]:
+ * those handlers should both support in capture phase and bubble phase!
+ *
  * @this {HandlerProxy}
  */
 var globalDOMHandlers = {
-
-    touchmove: function (event) {
-        markTouch(event);
-        globalDOMHandlers.mousemove.call(this, event);
-    },
-
-    touchend: function (event) {
-        markTouch(event);
-        globalDOMHandlers.mouseup.call(this, event);
-    },
 
     pointermove: function (event) {
         // FIXME
@@ -321,30 +335,31 @@ var globalDOMHandlers = {
     },
 
     mousemove: function (event) {
-        event = normalizeEvent(this.dom, event, true);
-        this.trigger('pagemousemove', event);
+        this.trigger('mousemove', event);
     },
 
     mouseup: function (event) {
-        event = normalizeEvent(this.dom, event, true);
-        this.trigger('pagemouseup', event);
-    }
-};
+        var pointerCaptureReleasing = this._pointerCapturing;
 
-// ----------------------------
-// Native event handlers END
-// ----------------------------
+        togglePointerCapture(this, false);
+
+        this.trigger('mouseup', event);
+
+        if (pointerCaptureReleasing) {
+            event.zrEventControl = 'only_globalout';
+            this.trigger('mouseout', event);
+        }
+    }
+
+};
 
 
 /**
  * @param {HandlerProxy} instance
  * @param {DOMHandlerScope} scope
- * @param {Object} nativeListenerNames {mouse: Array<string>, touch: Array<string>, poiner: Array<string>}
- * @param {boolean} localOrGlobal `true`: target local, `false`: target global.
  */
-function mountDOMEventListeners(instance, scope, nativeListenerNames, localOrGlobal) {
+function mountLocalDOMEventListeners(instance, scope) {
     var domHandlers = scope.domHandlers;
-    var domTarget = scope.domTarget;
 
     if (env.pointerEventsSupported) { // Only IE11+/Edge
         // 1. On devices that both enable touch and mouse (e.g., MS Surface and lenovo X240),
@@ -353,12 +368,10 @@ function mountDOMEventListeners(instance, scope, nativeListenerNames, localOrGlo
         // 2. On MS Surface, it probablely only trigger mousedown but no mouseup when tap on
         // screen, which do not occurs in pointer event.
         // So we use pointer event to both detect touch gesture and mouse behavior.
-        zrUtil.each(nativeListenerNames.pointer, function (nativeEventName) {
-            mountSingle(nativeEventName, function (event) {
-                if (localOrGlobal || !isTriggeredFromLocal(event)) {
-                    localOrGlobal && markTriggeredFromLocal(event);
-                    domHandlers[nativeEventName].call(instance, event);
-                }
+        zrUtil.each(localNativeListenerNames.pointer, function (nativeEventName) {
+            mountSingleDOMEventListener(scope, nativeEventName, function (event) {
+                // markTriggeredFromLocal(event);
+                domHandlers[nativeEventName].call(instance, event);
             });
         });
 
@@ -379,13 +392,11 @@ function mountDOMEventListeners(instance, scope, nativeListenerNames, localOrGlo
     }
     else {
         if (env.touchEventsSupported) {
-            zrUtil.each(nativeListenerNames.touch, function (nativeEventName) {
-                mountSingle(nativeEventName, function (event) {
-                    if (localOrGlobal || !isTriggeredFromLocal(event)) {
-                        localOrGlobal && markTriggeredFromLocal(event);
-                        domHandlers[nativeEventName].call(instance, event);
-                        setTouchTimer(scope);
-                    }
+            zrUtil.each(localNativeListenerNames.touch, function (nativeEventName) {
+                mountSingleDOMEventListener(scope, nativeEventName, function (event) {
+                    // markTriggeredFromLocal(event);
+                    domHandlers[nativeEventName].call(instance, event);
+                    setTouchTimer(scope);
                 });
             });
             // Handler of 'mouseout' event is needed in touch mode, which will be mounted below.
@@ -397,35 +408,93 @@ function mountDOMEventListeners(instance, scope, nativeListenerNames, localOrGlo
         // mouse event can not be handle in those devices.
         // 2. On MS Surface, Chrome will trigger both touch event and mouse event. How to prevent
         // mouseevent after touch event triggered, see `setTouchTimer`.
-        zrUtil.each(nativeListenerNames.mouse, function (nativeEventName) {
-            mountSingle(nativeEventName, function (event) {
+        zrUtil.each(localNativeListenerNames.mouse, function (nativeEventName) {
+            mountSingleDOMEventListener(scope, nativeEventName, function (event) {
                 event = getNativeEvent(event);
-                if (!scope.touching
-                    && (localOrGlobal || !isTriggeredFromLocal(event))
-                ) {
-                    localOrGlobal && markTriggeredFromLocal(event);
+                if (!scope.touching) {
+                    // markTriggeredFromLocal(event);
                     domHandlers[nativeEventName].call(instance, event);
                 }
             });
         });
     }
+}
 
-    function mountSingle(nativeEventName, listener) {
-        scope.mounted[nativeEventName] = listener;
-        addEventListener(domTarget, eventNameFix(nativeEventName), listener);
+/**
+ * @param {HandlerProxy} instance
+ * @param {DOMHandlerScope} scope
+ */
+function mountGlobalDOMEventListeners(instance, scope) {
+    // Only IE11+/Edge. See the comment in `mountLocalDOMEventListeners`.
+    if (env.pointerEventsSupported) {
+        zrUtil.each(globalNativeListenerNames.pointer, mount);
     }
+    // Touch event has implemented "drag outside" so we do not mount global listener for touch event.
+    // (see https://www.w3.org/TR/touch-events/#the-touchmove-event)
+    // We do not consider "both-support-touch-and-mouse device" for this feature (see the comment of
+    // `mountLocalDOMEventListeners`) to avoid bugs util some requirements come.
+    else if (!env.touchEventsSupported) {
+        zrUtil.each(globalNativeListenerNames.mouse, mount);
+    }
+
+    function mount(nativeEventName) {
+        function nativeEventListener(event) {
+            event = getNativeEvent(event);
+            // See the reason in [Drag outside] in `Handler.js`
+            // This checking supports both `useCapture` or not.
+            // PENDING: if there is performance issue in some devices,
+            // we probably can not use `useCapture` and change a easier
+            // to judes whether local (mark).
+            if (!isLocalEl(instance, event.target)) {
+                event = normalizeGlobalEvent(instance, event);
+                scope.domHandlers[nativeEventName].call(instance, event);
+            }
+        }
+        mountSingleDOMEventListener(
+            scope, nativeEventName, nativeEventListener,
+            {capture: true} // See [Drag Outside] in `Handler.js`
+        );
+    }
+}
+
+function mountSingleDOMEventListener(scope, nativeEventName, listener, opt) {
+    scope.mounted[nativeEventName] = listener;
+    scope.listenerOpts[nativeEventName] = opt;
+    addEventListener2(scope.domTarget, eventNameFix(nativeEventName), listener, opt);
 }
 
 function unmountDOMEventListeners(scope) {
     var mounted = scope.mounted;
     for (var nativeEventName in mounted) {
         if (mounted.hasOwnProperty(nativeEventName)) {
-            removeEventListener(scope.domTarget, eventNameFix(nativeEventName), mounted[nativeEventName]);
+            removeEventListener2(
+                scope.domTarget, eventNameFix(nativeEventName), mounted[nativeEventName],
+                scope.listenerOpts[nativeEventName]
+            );
         }
     }
     scope.mounted = {};
 }
 
+/**
+ * See [Drag Outside] in `Handler.js`.
+ * @implement
+ * @param {boolean} isPointerCapturing Should never be `null`/`undefined`.
+ *        `true`: start to capture pointer if it is not capturing.
+ *        `false`: end the capture if it is capturing.
+ */
+function togglePointerCapture(instance, isPointerCapturing) {
+    instance._mayPointerCapture = null;
+
+    if (globalEventSupported && (instance._pointerCapturing ^ isPointerCapturing)) {
+        instance._pointerCapturing = isPointerCapturing;
+
+        var globalHandlerScope = instance._globalHandlerScope;
+        isPointerCapturing
+            ? mountGlobalDOMEventListeners(instance, globalHandlerScope)
+            : unmountDOMEventListeners(globalHandlerScope);
+    }
+}
 
 /**
  * @inner
@@ -438,6 +507,7 @@ function DOMHandlerScope(domTarget, domHandlers) {
     // Key: eventName, value: mounted handler funcitons.
     // Used for unmount.
     this.mounted = {};
+    this.listenerOpts = {};
 
     this.touchTimer = null;
     this.touching = false;
@@ -447,27 +517,35 @@ function DOMHandlerScope(domTarget, domHandlers) {
  * @public
  * @class
  */
-function HandlerDomProxy(dom) {
+function HandlerDomProxy(dom, painterRoot) {
     Eventful.call(this);
 
     this.dom = dom;
+    this.painterRoot = painterRoot;
 
     this._localHandlerScope = new DOMHandlerScope(dom, localDOMHandlers);
 
-    if (pageEventSupported) {
+    if (globalEventSupported) {
         this._globalHandlerScope = new DOMHandlerScope(document, globalDOMHandlers);
     }
 
-    this._pageEventEnabled = false;
+    /**
+     * @type {boolean}
+     */
+    this._pointerCapturing = false;
+    /**
+     * @type {Array.<number>} [x, y] or null.
+     */
+    this._mayPointerCapture = null;
 
-    mountDOMEventListeners(this, this._localHandlerScope, localNativeListenerNames, true);
+    mountLocalDOMEventListeners(this, this._localHandlerScope);
 }
 
 var handlerDomProxyProto = HandlerDomProxy.prototype;
 
 handlerDomProxyProto.dispose = function () {
     unmountDOMEventListeners(this._localHandlerScope);
-    if (pageEventSupported) {
+    if (globalEventSupported) {
         unmountDOMEventListeners(this._globalHandlerScope);
     }
 };
@@ -476,24 +554,6 @@ handlerDomProxyProto.setCursor = function (cursorStyle) {
     this.dom.style && (this.dom.style.cursor = cursorStyle || 'default');
 };
 
-/**
- * The implementation of page event depends on listening to document.
- * So we should better only listen to that on needed, and remove the
- * listeners when do not need them to escape unexpected side-effect.
- * @param {boolean} enableOrDisable `true`: enable page event. `false`: disable page event.
- */
-handlerDomProxyProto.togglePageEvent = function (enableOrDisable) {
-    zrUtil.assert(enableOrDisable != null);
-
-    if (pageEventSupported && (this._pageEventEnabled ^ enableOrDisable)) {
-        this._pageEventEnabled = enableOrDisable;
-
-        var globalHandlerScope = this._globalHandlerScope;
-        enableOrDisable
-            ? mountDOMEventListeners(this, globalHandlerScope, globalNativeListenerNames)
-            : unmountDOMEventListeners(globalHandlerScope);
-    }
-};
 
 zrUtil.mixin(HandlerDomProxy, Eventful);
 

--- a/src/mixin/Draggable.js
+++ b/src/mixin/Draggable.js
@@ -3,8 +3,11 @@
 function Draggable() {
 
     this.on('mousedown', this._dragStart, this);
-    // this.on('mousemove', this._drag, this);
-    // this.on('mouseup', this._dragEnd, this);
+    this.on('mousemove', this._drag, this);
+    this.on('mouseup', this._dragEnd, this);
+    // `mosuemove` and `mouseup` can be continue to fire when dragging.
+    // See [Drag outside] in `Handler.js`. So we do not need to trigger
+    // `_dragEnd` when globalout. That would brings better user experience.
     // this.on('globalout', this._dragEnd, this);
 
     // this._dropTarget = null;
@@ -25,9 +28,6 @@ Draggable.prototype = {
             draggingTarget.dragging = true;
             this._x = e.offsetX;
             this._y = e.offsetY;
-
-            this.on('pagemousemove', this._drag, this);
-            this.on('pagemouseup', this._dragEnd, this);
 
             this.dispatchToElement(param(draggingTarget, e), 'dragstart', e.event);
         }
@@ -69,9 +69,6 @@ Draggable.prototype = {
         if (draggingTarget) {
             draggingTarget.dragging = false;
         }
-
-        this.off('pagemousemove', this._drag);
-        this.off('pagemouseup', this._dragEnd);
 
         this.dispatchToElement(param(draggingTarget, e), 'dragend', e.event);
 

--- a/src/mixin/Eventful.js
+++ b/src/mixin/Eventful.js
@@ -24,8 +24,6 @@ var arrySlice = Array.prototype.slice;
  *        return: {boolean}
  * @param {Function} [eventProcessor.afterTrigger] Called after all handlers called.
  *        param: {string} eventType
- * @param {Function} [eventProcessor.afterListenerChanged] Called when any listener added or removed.
- *        param: {string} eventType
  */
 var Eventful = function (eventProcessor) {
     this._$handlers = {};
@@ -105,8 +103,6 @@ Eventful.prototype = {
         else {
             delete _h[event];
         }
-
-        callListenerChanged(this, event);
 
         return this;
     },
@@ -238,13 +234,6 @@ Eventful.prototype = {
 };
 
 
-function callListenerChanged(eventful, eventType) {
-    var eventProcessor = eventful._$eventProcessor;
-    if (eventProcessor && eventProcessor.afterListenerChanged) {
-        eventProcessor.afterListenerChanged(eventType);
-    }
-}
-
 function normalizeQuery(host, query) {
     var eventProcessor = host._$eventProcessor;
     if (query != null && eventProcessor && eventProcessor.normalizeQuery) {
@@ -293,8 +282,6 @@ function on(eventful, event, query, handler, context, isOnce) {
     (lastWrap && lastWrap.callAtLast)
         ? _h[event].splice(lastIndex, 0, wrap)
         : _h[event].push(wrap);
-
-    callListenerChanged(eventful, event);
 
     return eventful;
 }
@@ -370,16 +357,6 @@ function on(eventful, event, query, handler, context, isOnce) {
  */
 /**
  * @event module:zrender/mixin/Eventful#ondrop
- * @type {Function}
- * @default null
- */
-/**
- * @event module:zrender/mixin/Eventful#onpagemousemove
- * @type {Function}
- * @default null
- */
-/**
- * @event module:zrender/mixin/Eventful#onpagemouseup
  * @type {Function}
  * @default null
  */

--- a/src/zrender.js
+++ b/src/zrender.js
@@ -130,7 +130,7 @@ var ZRender = function (id, dom, opts) {
     this.storage = storage;
     this.painter = painter;
 
-    var handerProxy = (!env.node && !env.worker) ? new HandlerProxy(painter.getViewportRoot()) : null;
+    var handerProxy = (!env.node && !env.worker) ? new HandlerProxy(painter.getViewportRoot(), painter.root) : null;
     this.handler = new Handler(storage, painter, handerProxy, painter.root);
 
     /**


### PR DESCRIPTION
<!-- Please fill in the following information to help us review your PR more efficiently. -->

## Brief Information

This pull request is in the type of:

- [ ] bug fixing
- [x] new feature
- [ ] others



### What does this PR do?

<!-- USE ONCE SENTENCE TO DESCRIBE WHAT THIS PR DOES. -->

The original merged PR is #536 and apache/incubator-echarts#11710 .
But here we make some changes now.

## Details

### Main changes

[Drag outside]:
 
That is, triggering `mousemove` and `mouseup` event when the pointer is out of the
zrender area when dragging. That is important for the improvement of the user experience
when dragging something near the boundary without being terminated unexpectedly.

We originally consider to introduce new events like `pagemovemove` and `pagemouseup`
to resolve this issue. 
Previously we provide "page event" in #536. 
But after further thinking, I think the the new way below is better.
Some drawbacks of it is described in
<https://github.com/ecomfe/zrender/pull/536#issuecomment-560286899>

Instead, we referenced the specifications:
<https://www.w3.org/TR/touch-events/#the-touchmove-event>
<https://www.w3.org/TR/2014/WD-DOM-Level-3-Events-20140925/#event-type-mousemove>
where the the `mousemove`/`touchmove` can be continue to fire if the user began a drag
operation and the pointer has left the boundary. (for the mouse event, browsers
only do it on `document` and when the pointer has left the boundary of the browser.)

So the default `HandlerProxy` supports this feature similarly: if it is in the dragging
state (see `pointerCapture` in `HandlerProxy`), the `mousemove` and `mouseup` continue
to fire until release the pointer. That is implemented by listen to those event on
`document`.
If we implement some other `HandlerProxy` only for touch device, that would be easier.
The touch event support this feature by default. (see `ecomfe/echarts-for-weixin`)

Note:
There might be some cases that the mouse event can not be
received on `document`. For example,
(A) `useCapture` is not supported and some user defined event listeners on the ancestor
of zr dom throw Error .
(B) `useCapture` is not supported Some user defined event listeners on the ancestor of
zr dom call `stopPropagation`.
In these cases, the `mousemove` event might be keep triggered event
if the mouse is released. We try to reduce the side-effect in those cases.
That is,
+ do nothing (especially, `findHover`) in those cases. See `isOutsideBoundary`.
+ `HandlerProxy` make a fake event but never expose the original native event to user. In the fake event, the `stopPropagation` and `preventDefault` is provided as a noop function. Becuase it is dangerous to enable users to call them in `document` capture phase to prevent the propagation to any listener of the webpage.

Note:
**By default, the document event is registered with `useCapture`.**
If some environment does not support `useCapture`, is OK. Because the implementation of document event listener does not depends on the sequence of calling. 
Specifically, when we need detect whether the target DOM is inside zrender area, we use the way of travel the `event.target` upward.

Note: 
Similarly to the browser did on `document` and touch event, `globalout` will be delayed to the final pointer cature release if the pointer is capturing.

Note: 
Why we use 

### Other changes

Deleted the code in `Handler.js` that "detect the dom in root". Because that code has been implemented in `HandlerProxy.js` and these code is relevant to DOM, which is probably better in `HandlerProxy.js`. But the original code in `HandlerProxy.js` does not work. Because it use `painter.getViewportRoot()` but not `painter.root`. Extra added DOM (like "echarts tooltip content" did) is not added to the viewport root but added to `painter.root`. So fixed it.



## Usage

### Related test cases or examples to use the new APIs

```
echarts/test/drag-out.html
echarts/test/css-transform.html
```
And the project `ecomfe/echarts-for-weixin` has been tested, where the default `HandlerProxy` is not used but implement another one for the "weapp" environment.

