### PR TITLE
support draggable on group

### DIFF
--- a/src/mixin/Draggable.js
+++ b/src/mixin/Draggable.js
@@ -20,7 +20,11 @@ Draggable.prototype = {
 
     _dragStart: function (e) {
         var draggingTarget = e.target;
-        if (draggingTarget && draggingTarget.draggable) {
+        // Find if there is draggable in the ancestor
+        while (draggingTarget && !draggingTarget.draggable) {
+            draggingTarget = draggingTarget.parent;
+        }
+        if (draggingTarget) {
             this._draggingTarget = draggingTarget;
             draggingTarget.dragging = true;
             this._x = e.offsetX;


### PR DESCRIPTION
This is a pull request about adding dragging support to the group elements.

It will find if any ancestor is set `draggable` and apply `drift` on it.