### PR TITLE
fix: fix subpixel optimize with no lineWidth

### DIFF
--- a/src/graphic/helper/subPixelOptimize.js
+++ b/src/graphic/helper/subPixelOptimize.js
@@ -21,9 +21,7 @@ var round = Math.round;
  * @param {number} [style.lineWidth]
  */
 export function subPixelOptimizeLine(outputShape, inputShape, style) {
-    var lineWidth = style && style.lineWidth;
-
-    if (!inputShape || !lineWidth) {
+    if (!inputShape) {
         return;
     }
 
@@ -32,19 +30,21 @@ export function subPixelOptimizeLine(outputShape, inputShape, style) {
     var y1 = inputShape.y1;
     var y2 = inputShape.y2;
 
+    outputShape.x1 = x1;
+    outputShape.x2 = x2;
+    outputShape.y1 = y1;
+    outputShape.y2 = y2;
+
+    var lineWidth = style && style.lineWidth;
+    if (!lineWidth) {
+        return;
+    }
+
     if (round(x1 * 2) === round(x2 * 2)) {
         outputShape.x1 = outputShape.x2 = subPixelOptimize(x1, lineWidth, true);
     }
-    else {
-        outputShape.x1 = x1;
-        outputShape.x2 = x2;
-    }
     if (round(y1 * 2) === round(y2 * 2)) {
         outputShape.y1 = outputShape.y2 = subPixelOptimize(y1, lineWidth, true);
-    }
-    else {
-        outputShape.y1 = y1;
-        outputShape.y2 = y2;
     }
 }
 
@@ -64,9 +64,7 @@ export function subPixelOptimizeLine(outputShape, inputShape, style) {
  * @param {number} [style.lineWidth]
  */
 export function subPixelOptimizeRect(outputShape, inputShape, style) {
-    var lineWidth = style && style.lineWidth;
-
-    if (!inputShape || !lineWidth) {
+    if (!inputShape) {
         return;
     }
 
@@ -74,6 +72,16 @@ export function subPixelOptimizeRect(outputShape, inputShape, style) {
     var originY = inputShape.y;
     var originWidth = inputShape.width;
     var originHeight = inputShape.height;
+
+    outputShape.x = originX;
+    outputShape.y = originY;
+    outputShape.width = originWidth;
+    outputShape.height = originHeight;
+
+    var lineWidth = style && style.lineWidth;
+    if (!lineWidth) {
+        return;
+    }
 
     outputShape.x = subPixelOptimize(originX, lineWidth, true);
     outputShape.y = subPixelOptimize(originY, lineWidth, true);

--- a/src/graphic/helper/subPixelOptimize.js
+++ b/src/graphic/helper/subPixelOptimize.js
@@ -18,7 +18,7 @@ var round = Math.round;
  * @param {number} [inputShape.x2]
  * @param {number} [inputShape.y2]
  * @param {Object} [style]
- * @param {number} [style.lineWidth]
+ * @param {number} [style.lineWidth] If `null`/`undefined`/`0`, do not optimize.
  */
 export function subPixelOptimizeLine(outputShape, inputShape, style) {
     if (!inputShape) {
@@ -61,7 +61,7 @@ export function subPixelOptimizeLine(outputShape, inputShape, style) {
  * @param {number} [inputShape.width]
  * @param {number} [inputShape.height]
  * @param {Object} [style]
- * @param {number} [style.lineWidth]
+ * @param {number} [style.lineWidth] If `null`/`undefined`/`0`, do not optimize.
  */
 export function subPixelOptimizeRect(outputShape, inputShape, style) {
     if (!inputShape) {
@@ -99,11 +99,14 @@ export function subPixelOptimizeRect(outputShape, inputShape, style) {
  * Sub pixel optimize for canvas
  *
  * @param {number} position Coordinate, such as x, y
- * @param {number} lineWidth Should be nonnegative integer.
+ * @param {number} lineWidth If `null`/`undefined`/`0`, do not optimize.
  * @param {boolean=} positiveOrNegative Default false (negative).
  * @return {number} Optimized position.
  */
 export function subPixelOptimize(position, lineWidth, positiveOrNegative) {
+    if (!lineWidth) {
+        return position;
+    }
     // Assure that (position + lineWidth / 2) is near integer edge,
     // otherwise line will be fuzzy in canvas.
     var doubledPosition = round(position * 2);


### PR DESCRIPTION

The interface `subPixelOptimize` should not make users consider `style.lineWidth`.
Should be:
```js
new Rect({
    subPixelOptimize: true
})
```

related: apache/incubator-echarts#11874 apache/incubator-echarts#11891

related PR: https://github.com/apache/incubator-echarts/pull/11991