### PR TITLE
feature: support convert between two local DOM coord. And some refactor.

### DIFF
--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -1,0 +1,150 @@
+
+import env from './env';
+import {buildTransformer} from './fourPointsTransform';
+
+var EVENT_SAVED_PROP = '___zrEVENTSAVED';
+var _calcOut = [];
+
+/**
+ * Transform "local coord" from `elFrom` to `elTarget`.
+ * "local coord": the coord based on the input `el`. The origin point is at
+ *     the position of "left: 0; top: 0;" in the `el`.
+ *
+ * Support when CSS transform is used.
+ *
+ * Having the `out` (that is, `[outX, outY]`), we can create an DOM element
+ * and set the CSS style as "left: outX; top: outY;" and append it to `elTarge`
+ * to locate the element.
+ *
+ * For example, this code below positions a child of `document.body` on the event
+ * point, no matter whether `body` has `margin`/`paddin`/`transfrom`/... :
+ * ```js
+ * transformLocalCoord(out, container, document.body, event.offsetX, event.offsetY);
+ * if (!eqNaN(out[0])) {
+ *     // Then locate the tip element on the event point.
+ *     var tipEl = document.createElement('div');
+ *     tipEl.style.cssText = 'position: absolute; left:' + out[0] + ';top:' + out[1] + ';';
+ *     document.body.appendChild(tipEl);
+ * }
+ * ```
+ *
+ * Notice: In some env this method is not supported. If called, `out` will be `[NaN, NaN]`.
+ *
+ * @param {Array.<number>} out [inX: number, inY: number] The output..
+ *        If can not transform, `out` will not be modified but return `false`.
+ * @param {HTMLElement} elFrom The `[inX, inY]` is based on elFrom.
+ * @param {HTMLElement} elTarget The `out` is based on elTarget.
+ * @param {number} inX
+ * @param {number} inY
+ * @return {boolean} Whether transform successfully.
+ */
+export function transformLocalCoord(out, elFrom, elTarget, inX, inY) {
+    return transformCoordWithViewport(_calcOut, elFrom, inX, inY, true)
+        && transformCoordWithViewport(out, elTarget, _calcOut[0], _calcOut[1]);
+}
+
+/**
+ * Transform between a "viewport coord" and a "local coord".
+ * "viewport coord": the coord based on the left-top corner of the viewport
+ *     of the browser.
+ * "local coord": the coord based on the input `el`. The origin point is at
+ *     the position of "left: 0; top: 0;" in the `el`.
+ *
+ * Support the case when CSS transform is used on el.
+ *
+ * @param {Array.<number>} out [inX: number, inY: number] The output. If `inverse: false`,
+ *        it represents "local coord", otherwise "vireport coord".
+ *        If can not transform, `out` will not be modified but return `false`.
+ * @param {HTMLElement} el The "local coord" is based on the `el`, see comment above.
+ * @param {number} inX If `inverse: false`,
+ *        it represents "vireport coord", otherwise "local coord".
+ * @param {number} inY If `inverse: false`,
+ *        it represents "vireport coord", otherwise "local coord".
+ * @param {boolean} [inverse=false]
+ *        `true`: from "viewport coord" to "local coord".
+ *        `false`: from "local coord" to "viewport coord".
+ * @return {boolean} Whether transform successfully.
+ */
+export function transformCoordWithViewport(out, el, inX, inY, inverse) {
+    if (el.getBoundingClientRect && env.domSupported && !isCanvasEl(el)) {
+        var saved = el[EVENT_SAVED_PROP] || (el[EVENT_SAVED_PROP] = {});
+        var markers = prepareCoordMarkers(el, saved);
+        var transformer = preparePointerTransformer(markers, saved, inverse);
+        if (transformer) {
+            transformer(out, inX, inY);
+            return true;
+        }
+    }
+    return false;
+}
+
+function prepareCoordMarkers(el, saved) {
+    var markers = saved.markers;
+    if (markers) {
+        return markers;
+    }
+
+    markers = saved.markers = [];
+    var propLR = ['left', 'right'];
+    var propTB = ['top', 'bottom'];
+
+    for (var i = 0; i < 4; i++) {
+        var marker = document.createElement('div');
+        var stl = marker.style;
+        var idxLR = i % 2;
+        var idxTB = (i >> 1) % 2;
+        stl.cssText = [
+            'position: absolute',
+            'visibility: hidden',
+            'padding: 0',
+            'margin: 0',
+            'border-width: 0',
+            'user-select: none',
+            'width:0',
+            'height:0',
+            // 'width: 5px',
+            // 'height: 5px',
+            propLR[idxLR] + ':0',
+            propTB[idxTB] + ':0',
+            propLR[1 - idxLR] + ':auto',
+            propTB[1 - idxTB] + ':auto',
+            ''
+        ].join('!important;');
+        el.appendChild(marker);
+        markers.push(marker);
+    }
+
+    return markers;
+}
+
+function preparePointerTransformer(markers, saved, inverse) {
+    var transformerName = inverse ? 'invTrans' : 'trans';
+    var transformer = saved[transformerName];
+    var oldSrcCoords = saved.srcCoords;
+    var oldCoordTheSame = true;
+    var srcCoords = [];
+    var destCoords = [];
+
+    for (var i = 0; i < 4; i++) {
+        var rect = markers[i].getBoundingClientRect();
+        var ii = 2 * i;
+        var x = rect.left;
+        var y = rect.top;
+        srcCoords.push(x, y);
+        oldCoordTheSame = oldCoordTheSame && oldSrcCoords && x === oldSrcCoords[ii] && y === oldSrcCoords[ii + 1];
+        destCoords.push(markers[i].offsetLeft, markers[i].offsetTop);
+    }
+    // Cache to avoid time consuming of `buildTransformer`.
+    return (oldCoordTheSame && transformer)
+        ? transformer
+        : (
+            saved.srcCoords = srcCoords,
+            saved[transformerName] = inverse
+                ? buildTransformer(destCoords, srcCoords)
+                : buildTransformer(srcCoords, destCoords)
+        );
+}
+
+export function isCanvasEl(el) {
+    return el.nodeName.toUpperCase() === 'CANVAS';
+}

--- a/src/core/fourPointsTransform.js
+++ b/src/core/fourPointsTransform.js
@@ -76,6 +76,8 @@ export function buildTransformer(src, dest) {
     var detCache = {};
     var det = determinant(mA, 8, 0, 0, 0, detCache);
     if (det === 0) {
+        // can not make transformer when and only when
+        // any three of the markers are collinear.
         return;
     }
 

--- a/src/dom/HandlerProxy.js
+++ b/src/dom/HandlerProxy.js
@@ -117,13 +117,16 @@ function normalizeGlobalEvent(instance, event) {
  * Detect whether the given el is in `painterRoot`.
  */
 function isLocalEl(instance, el) {
+    var elTmp = el;
     var isLocal = false;
-    do {
-        el = el && el.parentNode;
+    while (elTmp && elTmp.nodeType !== 9
+        && !(
+            isLocal = elTmp.domBelongToZr
+                || (elTmp !== el && elTmp === instance.painterRoot)
+        )
+    ) {
+        elTmp = elTmp.parentNode;
     }
-    while (el && el.nodeType !== 9 && !(
-        isLocal = el === instance.painterRoot
-    ));
     return isLocal;
 }
 

--- a/test/css-transform-inverse.html
+++ b/test/css-transform-inverse.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="lib/facePrint.js"></script>
+        <script src="lib/rollup.browser.js"></script>
+        <script src="lib/requireES.js"></script>
+        <script src="lib/config.js"></script>
+    </head>
+    <body>
+        <style>
+            html {
+                position: static;
+                perspective: 371px;
+            }
+            body {
+                position: static;
+                background: #ffe;
+                transform: scale3d(0.7, 0.8, 1) rotateY(-18deg) rotateZ(-32deg);
+                transform-style: preserve-3d;
+            }
+            .chart {
+                position: relative;
+                width: 500px;
+                height: 300px;
+                border: 10px solid rgba(0,0,0,0.5);
+                margin: 30px auto 30px auto;
+            }
+            select {
+                font-size: 16px;
+                color: rgb(107, 8, 8);
+            }
+            .try-box {
+                position: relative;
+                background: green;
+                padding: 0;
+                border-width: 0;
+                line-height: 1;
+                text-align: center;
+                font-size: 12px;
+                color: yellow;
+                /* box-sizing: content-box; */
+            }
+            .try-box-check {
+                position: absolute;
+                background: grey;
+                padding: 0;
+                border-width: 0;
+                line-height: 1;
+                text-align: center;
+                font-size: 12px;
+            }
+            .pointer-marker {
+                position: absolute;
+                width: 6px;
+                height: 6px;
+                margin: -3px 0 0 -3px;
+                padding: 0;
+                background: orange;
+            }
+        </style>
+
+        <div id="boundingRectPainter"
+            style="display: none; z-index: 99; position: absolute; left: 0; top: 0; width: 100%; height: 100%">
+        </div>
+
+        <div style="position: fixed; top: 0; left: 3px; font-size: 16px">
+            Test: convert zrX/zrY to body left/top (the document.body is CSS transformed): <br>
+            Click the green rect, should show orange rect under the pointer.
+        </div>
+
+        <div id="allTries" style="display:none">
+
+            <div id="try0" style="
+                    perspective: 171px;
+                "
+            >
+                <div class="try-box"
+                    style="
+                        width: 150px; height: 100px;
+                        left: 100px; top: 300px;
+                        /* margin: 20px; */
+                        position: absolute;
+                        transform: translateX(50px) rotateY(28deg) rotateX(18deg);
+                        transform-style: preserve-3d;
+                        transform-origin: 0 0;
+                    "
+                >normal transform 3d
+                </div>
+            </div>
+
+
+            <div id="try2" style="">
+                <div class="try-box"
+                    style="
+                        width: 200px; height: 150px;
+                        left: 100px; top: 300px;
+                        margin: 20px;
+                        transform: translate(-50px, 50px) scale(-0.8, 0.5) rotate(-25deg);
+                    "
+                >transform 2d with nagative value
+                </div>
+            </div>
+
+            <div id="try3" style="">
+                <div style="
+                    transform: translate(50px, 360px) scale(-0.8, 0.5) rotate(-25deg);
+                ">
+                    <div class="try-box"
+                        style="
+                            width: 200px; height: 150px;
+                            left: 100px; top: 300px;
+                            margin: 20px;
+                            transform: translate(40px, -200px) scale(1.3, 3) rotate(65deg);
+                        "
+                    >nested transform 2d
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+
+
+
+
+
+        <script>
+
+            var $drawRect;
+
+            (function () {
+                var boundingRectPainter = document.getElementById('boundingRectPainter');
+
+                document.addEventListener('click', function (e) {
+                    console.log(e.clientX, e.clientY, e.target);
+                    facePrint({clientX: e.clientX, clientY: e.clientY});
+                })
+
+                $drawRect = function (rect) {
+                    var rectDom = document.createElement('div');
+                    rectDom.style.cssText = [
+                        'left: ' + rect.left.toFixed(0) + 'px',
+                        'top: ' + rect.top.toFixed(0) + 'px',
+                        'width: ' + rect.width.toFixed(0) + 'px',
+                        'height: ' + rect.height.toFixed(0) + 'px',
+                        'position: absolute',
+                        'border: 1px solid red',
+                        'margin: 0',
+                        'padding: 0',
+                        ''
+                    ].join(';');
+                    boundingRectPainter.appendChild(rectDom);
+                }
+
+            })();
+        </script>
+
+
+
+        <script>
+            requireES(
+                [
+                    'zrender/src/zrender',
+                    'zrender/src/core/dom',
+                    'zrender/src/graphic/shape/Polyline',
+                    'zrender/src/graphic/shape/Rect'
+                ],
+                initAllTry
+            );
+
+            function initAllTry(zrender, domUtil, Polyline, Rect) {
+                var allTries = document.getElementById('allTries');
+                allTries.style.display = 'block';
+
+                initSingleTry(document.getElementById('try0'));
+                initSingleTry(document.getElementById('try2'));
+                initSingleTry(document.getElementById('try3'));
+
+                function initSingleTry(tryDom) {
+                    var tryBox = tryDom.querySelector('.try-box');
+
+                    var zr = zrender.init(tryBox, {
+                        renderer: 'canvas'
+                    });
+                    zr.on('click', function (e) {
+                        console.log('handle click');
+                        drawPointer(zr, e);
+                    });
+                }
+
+                function drawPointer(zr, zrEvent) {
+                    var zrX = zrEvent.offsetX;
+                    var zrY = zrEvent.offsetY;
+                    var bodyCoord = [];
+                    domUtil.transformLocalCoord(
+                        bodyCoord, zr.painter.getViewportRoot(), document.body, zrX, zrY
+                    );
+
+                    var pointerMarker = document.createElement('div');
+                    pointerMarker.classList.add('pointer-marker');
+                    pointerMarker.style.left = bodyCoord[0] + 'px';
+                    pointerMarker.style.top = bodyCoord[1] + 'px';
+                    document.body.appendChild(pointerMarker);
+                }
+            }
+        </script>
+
+
+
+
+
+
+
+
+    </body>
+</html>


### PR DESCRIPTION
It usually use on the case: 

We have `[zrX, zrY]`. we want to get the corresponding `[left, top]` of another DOM element (for example, `document.body`, or vise versa.
It can be used on the positioning of echarts tooltip which is appended to `document.body`.
