### PR TITLE
Revert "fix(svg): use lower case for clippath"

### DIFF
--- a/src/svg/helper/ClippathManager.js
+++ b/src/svg/helper/ClippathManager.js
@@ -83,7 +83,7 @@ ClippathManager.prototype.updateDom = function (
             // New <clipPath>
             id = 'zr' + this._zrId + '-clip-' + this.nextId;
             ++this.nextId;
-            clipPathEl = this.createElement('clippath');
+            clipPathEl = this.createElement('clipPath');
             clipPathEl.setAttribute('id', id);
             defs.appendChild(clipPathEl);
 


### PR DESCRIPTION
This reverts commit 2639dcef6961a6a613a993d8b80e32082b8b262a, which will cause clipping failue in main browsers.