### PR TITLE
feat(mousemove): mouse event changed from active trigger to passive t…

### DIFF
--- a/src/zrender.js
+++ b/src/zrender.js
@@ -165,6 +165,13 @@ var ZRender = function (id, dom, opts) {
 
         el.addSelfToZr(self);
     };
+
+    // 被动触发元素上的鼠标事件。当鼠标在画布上静止时，
+    // 如果此时因为动画，有元素移入鼠标指针的位置，
+    // 此时也会触发元素的鼠标事件。
+    this.animation.on('frame', function () {
+        self.handler.dispatchToAny();
+    });
 };
 
 ZRender.prototype = {

--- a/test/animation-mouse.html
+++ b/test/animation-mouse.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Animation</title>
+    <script src="../dist/zrender.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+        html, body, #main {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+<body>
+    <div id="main"></div>
+    <script type="text/javascript">
+        var main = document.getElementById('main');
+        // 初始化zrender
+        var zr = zrender.init(main);
+
+        var gradient = new zrender.LinearGradient();
+        gradient.addColorStop(0, 'red');
+        gradient.addColorStop(1, 'black');
+
+        var circle = new zrender.Circle({
+            position: [100, 100],
+            scale: [1, 1],
+            shape: {
+                cx: 50,
+                cy: 50,
+                r: 50
+            },
+            style: {
+                fill: gradient,
+                lineWidth: 5,
+                text:'circle',
+                textPosition:'inside'
+            }
+        });
+        zr.add(circle);
+
+        circle.animate('')
+            .when(200, {
+                position: [200, 0]
+            })
+            .start();
+        circle.animate('', true)
+            .when(1000, {
+                position: [200, 0]
+            })
+            .when(2000, {
+                position: [200, 200]
+            })
+            .when(3000, {
+                position: [0, 200]
+            })
+            .when(4000, {
+                position: [100, 100]
+            })
+            .start();
+
+        circle.on('mouseout', function () {
+            circle.attr({
+                style: {
+                    fill: gradient
+                }
+            })
+        });
+
+        circle.on('mouseover', function () {
+            circle.attr({
+                style: {
+                    fill: 'blue'
+                }
+            })
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### 添加了什么功能？

当鼠标指针静止时，此时如果有元素因为动画移动到或移出鼠标的位置，就触发对应的鼠标事件。

### 之前的样子

这是之前的效果，如图所示：
![captured (1)](https://user-images.githubusercontent.com/38434641/81771026-8155f480-9514-11ea-8875-08a694a0331d.gif)
鼠标静止时，元素移动到指针的位置，没有触发对应的事件。

### 现在的样子

这是现在的效果，如图所示：
![captured (2)](https://user-images.githubusercontent.com/38434641/81771120-b6624700-9514-11ea-93a5-8051c4fbcc27.gif)
鼠标静止时，元素移动到指针的时候触发元素的`mouseover`事件，元素从指针位置移出时触发`mouseout`事件。

### 为什么要这样？

有这个想法是因为echarts的一个[BUG](https://github.com/apache/incubator-echarts/issues/12248)，我想它的原因应该是跟鼠标静止时，元素因为动画移出鼠标指针的位置但未触发相应的事件有关。但事实证明我的想法是错误的，因为当我改完代码运行测试时这个BUG并没有消失。

但我想这应该是一个好的功能，我观察了浏览器的行为(如下图所示)，当鼠标静止时，DOM元素自动滑动到鼠标指针时，会触发相应的事件。所以我就坚持提交了这个PR。但这可能会引发其它的问题，所以如果你感到任何的不妥，请随时关闭这个PR。
![captured (3)](https://user-images.githubusercontent.com/38434641/81772089-76509380-9517-11ea-8bf9-bf25de29578d.gif)
