### PR TITLE
Update GradientManager.js

### DIFF
--- a/src/svg/helper/GradientManager.js
+++ b/src/svg/helper/GradientManager.js
@@ -180,7 +180,7 @@ GradientManager.prototype.updateDom = function (gradient, dom) {
         stop.setAttribute('offset', colors[i].offset * 100 + '%');
 
         var color = colors[i].color;
-        if (color.indexOf('rgba' > -1)) {
+        if (color.indexOf('rgba') > -1) {
             // Fix Safari bug that stop-color not recognizing alpha #9014
             var opacity = colorTool.parse(color)[3];
             var hex = colorTool.toHex(color);


### PR DESCRIPTION
This merge requests fixes `rgba` string detection in `GradientManager.js`.

I came across this error while using echarts with svg-renderer and a gradient areastyle on a series.

The original stacktrace of the error for version 4.3.1 is :
```
TypeError: Cannot read property '3' of undefined
    at GradientManager.push../node_modules/zrender/lib/svg/helper/GradientManager.js.GradientManager.updateDom (GradientManager.js:164)
    at GradientManager.push../node_modules/zrender/lib/svg/helper/GradientManager.js.GradientManager.add (GradientManager.js:93)
    at GradientManager.push../node_modules/zrender/lib/svg/helper/Definable.js.Definable.update (Definable.js:118)
    at GradientManager.push../node_modules/zrender/lib/svg/helper/GradientManager.js.GradientManager.update (GradientManager.js:106)
```