### PR TITLE
Fix echarts datazoom: add 'keys' method to HashMap

### DIFF
--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -698,6 +698,10 @@ export class HashMap<T, KEY extends string | number = string | number> {
     removeKey(key: KEY) {
         delete this.data[key];
     }
+
+    keys() {
+        return keys(this.data);
+    }
 }
 
 export function createHashMap<T, KEY extends string | number = string | number>(


### PR DESCRIPTION
https://github.com/apache/incubator-echarts/blob/next/src/component/dataZoom/DataZoomModel.ts#L546

TS throw error that said: `DataZoomTargetAxisInfoMap ` don't have `keys` method