### PR TITLE
fix(hover): hover layer should be created only if having hover elements

### DIFF
--- a/src/canvas/Painter.ts
+++ b/src/canvas/Painter.ts
@@ -268,27 +268,33 @@ export default class CanvasPainter implements PainterBase {
             return;
         }
 
-        // Use a extream large zlevel
-        // FIXME?
-        if (!hoverLayer) {
-            hoverLayer = this._hoverlayer = this.getLayer(HOVER_LAYER_ZLEVEL);
-        }
-
         const scope: BrushScope = {
             inHover: true,
             viewWidth: this._width,
             viewHeight: this._height
         };
-        const ctx = hoverLayer.ctx;
-        ctx.save();
+
+        let ctx;
         for (let i = 0; i < len; i++) {
             const el = list[i];
             if (el.__inHover) {
-                // el.
+                // Use a extream large zlevel
+                // FIXME?
+                if (!hoverLayer) {
+                    hoverLayer = this._hoverlayer = this.getLayer(HOVER_LAYER_ZLEVEL);
+                }
+
+                if (!ctx) {
+                    ctx = hoverLayer.ctx;
+                    ctx.save();
+                }
+
                 brush(ctx, el, scope, i === len - 1);
             }
         }
-        ctx.restore();
+        if (ctx) {
+            ctx.restore();
+        }
     }
 
     getHoverLayer() {


### PR DESCRIPTION
Before: hover layer is always created for all charts.
After: hover layer is only created when there is elements in hover layer.