### PR TITLE
fix: fix compatibility in IE and logic flaw of `requestAnimationFrame`.

### DIFF
--- a/src/Element.ts
+++ b/src/Element.ts
@@ -23,6 +23,7 @@ import Group from './graphic/Group';
 import Point from './core/Point';
 import { LIGHT_LABEL_COLOR, DARK_LABEL_COLOR } from './config';
 import { parse, stringify } from './tool/color';
+import env from './core/env';
 
 export interface ElementAnimateConfig {
     duration?: number
@@ -1615,7 +1616,7 @@ class Element<Props extends ElementProps = ElementProps> {
                 });
             }
         }
-        if (Object.defineProperty) {
+        if (Object.defineProperty && (!(env as any).browser.ie || (env as any).browser.version > 8)) {
             createLegacyProperty('position', '_legacyPos', 'x', 'y');
             createLegacyProperty('scale', '_legacyScale', 'scaleX', 'scaleY');
             createLegacyProperty('origin', '_legacyOrigin', 'originX', 'originY');

--- a/src/animation/requestAnimationFrame.ts
+++ b/src/animation/requestAnimationFrame.ts
@@ -2,17 +2,15 @@ type RequestAnimationFrameType = typeof window.requestAnimationFrame
 
 let requestAnimationFrame: RequestAnimationFrameType;
 
-if (typeof window !== 'undefined') {
-    requestAnimationFrame = (window.requestAnimationFrame && window.requestAnimationFrame.bind(window))
-        // https://github.com/ecomfe/zrender/issues/189#issuecomment-224919809
-        || ((window as any).msRequestAnimationFrame && (window as any).msRequestAnimationFrame.bind(window))
-        || (window as any).mozRequestAnimationFrame
-        || window.webkitRequestAnimationFrame;
-}
-else {
-    requestAnimationFrame = function (func: Parameters<RequestAnimationFrameType>[0]): number {
-        return setTimeout(func, 16) as any;
-    };
-}
+requestAnimationFrame = (
+	typeof window !== 'undefined'
+		&& (window.requestAnimationFrame && window.requestAnimationFrame.bind(window))
+    	// https://github.com/ecomfe/zrender/issues/189#issuecomment-224919809
+    	|| ((window as any).msRequestAnimationFrame && (window as any).msRequestAnimationFrame.bind(window))
+   	 	|| (window as any).mozRequestAnimationFrame
+    	|| window.webkitRequestAnimationFrame)
+	|| function (func: Parameters<RequestAnimationFrameType>[0]): number {
+	    return setTimeout(func, 16) as any;
+	};
 
 export default requestAnimationFrame;

--- a/src/animation/requestAnimationFrame.ts
+++ b/src/animation/requestAnimationFrame.ts
@@ -5,11 +5,11 @@ let requestAnimationFrame: RequestAnimationFrameType;
 requestAnimationFrame = (
 	typeof window !== 'undefined'
 		&& (window.requestAnimationFrame && window.requestAnimationFrame.bind(window))
-    	// https://github.com/ecomfe/zrender/issues/189#issuecomment-224919809
-    	|| ((window as any).msRequestAnimationFrame && (window as any).msRequestAnimationFrame.bind(window))
-   	 	|| (window as any).mozRequestAnimationFrame
-    	|| window.webkitRequestAnimationFrame)
-	|| function (func: Parameters<RequestAnimationFrameType>[0]): number {
+		// https://github.com/ecomfe/zrender/issues/189#issuecomment-224919809
+		|| ((window as any).msRequestAnimationFrame && (window as any).msRequestAnimationFrame.bind(window))
+		|| (window as any).mozRequestAnimationFrame
+		|| window.webkitRequestAnimationFrame
+	) || function (func: Parameters<RequestAnimationFrameType>[0]): number {
 	    return setTimeout(func, 16) as any;
 	};
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,9 @@ let dpr = 1;
 
 // If in browser environment
 if (typeof window !== 'undefined') {
-    dpr = Math.max(window.devicePixelRatio || 1, 1);
+    dpr = Math.max(window.devicePixelRatio 
+    	|| ((window.screen as any).deviceXDPI / (window.screen as any).logicalXDPI) 
+    	|| 1, 1);
 }
 
 /**


### PR DESCRIPTION
**1) Fix incorrect logic of `requestAnimationFrame`.**

There is a flaw in the judgment about `requestAnimationFrame`.

**2) Make `devicePixelRatio` compatible with IE8/9/10.**

IE which has a version small than 11 has no `window.devicePixelRatio`, but can be calculated by
```js
window.screen.deviceXDPI / window.screen.logicalXDPI
```

**3) Don't call `Object.defineProperty` in IE8.**

Although IE8 has the method `Object.defineProperty`, it's only supported on DOM objects and with some non-standard behaviors.

> Reference: [Internet_Explorer_8_specific_notes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#Internet_Explorer_8_specific_notes)