### PR TITLE
fix(tool/color): enhance the color compat.

### DIFF
--- a/src/tool/color.ts
+++ b/src/tool/color.ts
@@ -180,25 +180,28 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
         return rgbaArr;
     }
 
-    // #abc and #abc123 syntax.
+    // supports the forms #rgb, #rrggbb, #rgba, #rrggbbaa
+    // #rrggbbaa(use the last pair of digits as alpha)
+    // see https://drafts.csswg.org/css-color/#hex-notation
     if (str.charAt(0) === '#') {
-        if (str.length === 4) {
-            let iv = parseInt(str.substr(1), 16);  // TODO(deanm): Stricter parsing.
+        if (str.length === 4 || str.length === 5) {
+            const iv = parseInt(str.slice(1, 4), 16);  // TODO(deanm): Stricter parsing.
             if (!(iv >= 0 && iv <= 0xfff)) {
                 setRgba(rgbaArr, 0, 0, 0, 1);
                 return;  // Covers NaN.
             }
+            // interpret values of the form #rgb as #rrggbb and #rgba as #rrggbbaa
             setRgba(rgbaArr,
                 ((iv & 0xf00) >> 4) | ((iv & 0xf00) >> 8),
                 (iv & 0xf0) | ((iv & 0xf0) >> 4),
                 (iv & 0xf) | ((iv & 0xf) << 4),
-                1
+                str.length === 5 ? parseInt(str.slice(4), 16) / 0xf : 1
             );
             putToCache(colorStr, rgbaArr);
             return rgbaArr;
         }
-        else if (str.length === 7) {
-            const iv = parseInt(str.substr(1), 16);  // TODO(deanm): Stricter parsing.
+        else if (str.length === 7 || str.length === 9) {
+            const iv = parseInt(str.slice(1, 7), 16);  // TODO(deanm): Stricter parsing.
             if (!(iv >= 0 && iv <= 0xffffff)) {
                 setRgba(rgbaArr, 0, 0, 0, 1);
                 return;  // Covers NaN.
@@ -207,7 +210,7 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
                 (iv & 0xff0000) >> 16,
                 (iv & 0xff00) >> 8,
                 iv & 0xff,
-                1
+                str.length === 9 ? parseInt(str.slice(7), 16) / 0xff : 1
             );
             putToCache(colorStr, rgbaArr);
             return rgbaArr;
@@ -224,8 +227,10 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
         switch (fname) {
             case 'rgba':
                 if (params.length !== 4) {
-                    setRgba(rgbaArr, 0, 0, 0, 1);
-                    return;
+                    return params.length === 3
+                        // to be compatible with rgb
+                        ? setRgba(rgbaArr, +params[0], +params[1], +params[2], 1)
+                        : setRgba(rgbaArr, 0, 0, 0, 1);
                 }
                 alpha = parseCssFloat(params.pop() as string); // jshint ignore:line
             // Fall through.

--- a/src/tool/color.ts
+++ b/src/tool/color.ts
@@ -183,8 +183,9 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
     // supports the forms #rgb, #rrggbb, #rgba, #rrggbbaa
     // #rrggbbaa(use the last pair of digits as alpha)
     // see https://drafts.csswg.org/css-color/#hex-notation
+    const strLen = str.length;
     if (str.charAt(0) === '#') {
-        if (str.length === 4 || str.length === 5) {
+        if (strLen === 4 || strLen === 5) {
             const iv = parseInt(str.slice(1, 4), 16);  // TODO(deanm): Stricter parsing.
             if (!(iv >= 0 && iv <= 0xfff)) {
                 setRgba(rgbaArr, 0, 0, 0, 1);
@@ -195,12 +196,12 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
                 ((iv & 0xf00) >> 4) | ((iv & 0xf00) >> 8),
                 (iv & 0xf0) | ((iv & 0xf0) >> 4),
                 (iv & 0xf) | ((iv & 0xf) << 4),
-                str.length === 5 ? parseInt(str.slice(4), 16) / 0xf : 1
+                strLen === 5 ? parseInt(str.slice(4), 16) / 0xf : 1
             );
             putToCache(colorStr, rgbaArr);
             return rgbaArr;
         }
-        else if (str.length === 7 || str.length === 9) {
+        else if (strLen === 7 || strLen === 9) {
             const iv = parseInt(str.slice(1, 7), 16);  // TODO(deanm): Stricter parsing.
             if (!(iv >= 0 && iv <= 0xffffff)) {
                 setRgba(rgbaArr, 0, 0, 0, 1);
@@ -210,7 +211,7 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
                 (iv & 0xff0000) >> 16,
                 (iv & 0xff00) >> 8,
                 iv & 0xff,
-                str.length === 9 ? parseInt(str.slice(7), 16) / 0xff : 1
+                strLen === 9 ? parseInt(str.slice(7), 16) / 0xff : 1
             );
             putToCache(colorStr, rgbaArr);
             return rgbaArr;
@@ -220,7 +221,7 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
     }
     let op = str.indexOf('(');
     let ep = str.indexOf(')');
-    if (op !== -1 && ep + 1 === str.length) {
+    if (op !== -1 && ep + 1 === strLen) {
         let fname = str.substr(0, op);
         let params: (number | string)[] = str.substr(op + 1, ep - (op + 1)).split(',');
         let alpha = 1;  // To allow case fallthrough.

--- a/test/ut/spec/tool/color.test.ts
+++ b/test/ut/spec/tool/color.test.ts
@@ -2,8 +2,8 @@ import * as colorTool from '../../../../src/tool/color';
 
 describe('colorTool', function () {
 
-	it(`\`rgba(17, 263, 69)\` should be converted to [17, 263, 69, 1]`, function () {
-		expect(colorTool.parse('rgba(17, 263, 69)')).toEqual([17, 263, 69, 1]);
+	it(`\`rgba(17, 163, 69)\` should be converted to [17, 163, 69, 1]`, function () {
+		expect(colorTool.parse('rgba(17, 163, 69)')).toEqual([17, 163, 69, 1]);
 	});
 
 	it(`\`#14c4baff\` should be converted to [20, 196, 186, 1]`, function () {

--- a/test/ut/spec/tool/color.test.ts
+++ b/test/ut/spec/tool/color.test.ts
@@ -1,6 +1,6 @@
 import * as colorTool from '../../../../src/tool/color';
 
-describe('colorTool', function() {
+describe('colorTool', function () {
 
 	it(`\`rgba(17, 263, 69)\` should be converted to [17, 263, 69, 1]`, function () {
 		expect(colorTool.parse('rgba(17, 263, 69)')).toEqual([17, 263, 69, 1]);
@@ -14,4 +14,4 @@ describe('colorTool', function() {
 		expect(colorTool.parse('#07f0')).toEqual([0, 119, 255, 0]);
 	});
 
-})
+});

--- a/test/ut/spec/tool/color.test.ts
+++ b/test/ut/spec/tool/color.test.ts
@@ -1,0 +1,17 @@
+import * as colorTool from '../../../../src/tool/color';
+
+describe('colorTool', function() {
+
+	it(`\`rgba(17, 263, 69)\` should be converted to [17, 263, 69, 1]`, function () {
+		expect(colorTool.parse('rgba(17, 263, 69)')).toEqual([17, 263, 69, 1]);
+	});
+
+	it(`\`#14c4baff\` should be converted to [20, 196, 186, 1]`, function () {
+		expect(colorTool.parse('#14c4baff')).toEqual([20, 196, 186, 1]);
+	});
+
+	it(`\`#07f0\` should be converted to [0, 119, 255, 0]`, function () {
+		expect(colorTool.parse('#07f0')).toEqual([0, 119, 255, 0]);
+	});
+
+})


### PR DESCRIPTION
### Changes

(1) add fallback for `rgba(r, g, b)`. It will be converted to `rgba(r, g, b, 1)`.
(2) support 8-digit hex color(`#rrggbbaa`) which uses the last pair of digits as alpha, see https://drafts.csswg.org/css-color/#hex-notation and also support the form of `#rgba` (4-digit hex color in the form of `#rgba`).

### Results

(1) `rgba(17, 163, 69)` will be converted to `[17, 163, 69, 1]` **(Previous result is `undefined`)**
(2) `#14c4baff` will be converted to `[20, 196, 186, 1]` **(Previous result is `undefined`)**
(3) `#07f0` will be converted to `[0, 119, 255, 0]` **(Previous result is `undefined`)**

### Fixed issues

This fixes apache/incubator-echarts#13433 and enables the forms of color to be more flexible.

### Test cases
Please refer to `test/ut/spec/tool/color.test.ts`
