### PR TITLE
fix(sector): skip drawing corner radius if no arc.

### DIFF
--- a/src/graphic/helper/roundSector.ts
+++ b/src/graphic/helper/roundSector.ts
@@ -109,6 +109,20 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
         return;
     }
 
+    const clockwise = !!shape.clockwise;
+    const startAngle = shape.startAngle;
+    const endAngle = shape.endAngle;
+
+    // FIXME: whether normalizing angles is required?
+    const tmpAngles = [startAngle, endAngle];
+    normalizeArcAngles(tmpAngles, !clockwise);
+
+    const arc = mathAbs(tmpAngles[0] - tmpAngles[1]);
+    // no arc
+    if (!(arc > e)) {
+        return;
+    }
+
     if (!hasRadius) {
         // use innerRadius as radius if no radius
         radius = innerRadius;
@@ -124,17 +138,8 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
 
     const x = shape.cx;
     const y = shape.cy;
-    const clockwise = !!shape.clockwise;
-    const startAngle = shape.startAngle;
-    const endAngle = shape.endAngle;
     const cornerRadius = shape.cornerRadius || 0;
     const innerCornerRadius = shape.innerCornerRadius || 0;
-
-    // FIXME: whether normalizing angles is required?
-    const tmpAngles = [startAngle, endAngle];
-    normalizeArcAngles(tmpAngles, !clockwise);
-
-    const arc = mathAbs(tmpAngles[0] - tmpAngles[1]);
 
     // is a point
     if (!(radius > e)) {

--- a/src/graphic/helper/roundSector.ts
+++ b/src/graphic/helper/roundSector.ts
@@ -109,20 +109,6 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
         return;
     }
 
-    const clockwise = !!shape.clockwise;
-    const startAngle = shape.startAngle;
-    const endAngle = shape.endAngle;
-
-    // FIXME: whether normalizing angles is required?
-    const tmpAngles = [startAngle, endAngle];
-    normalizeArcAngles(tmpAngles, !clockwise);
-
-    const arc = mathAbs(tmpAngles[0] - tmpAngles[1]);
-    // no arc
-    if (!(arc > e)) {
-        return;
-    }
-
     if (!hasRadius) {
         // use innerRadius as radius if no radius
         radius = innerRadius;
@@ -135,6 +121,15 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
         radius = innerRadius;
         innerRadius = tmp;
     }
+
+    const clockwise = !!shape.clockwise;
+    const startAngle = shape.startAngle;
+    const endAngle = shape.endAngle;
+
+    // FIXME: whether normalizing angles is required?
+    const tmpAngles = [startAngle, endAngle];
+    normalizeArcAngles(tmpAngles, !clockwise);
+    const arc = mathAbs(tmpAngles[0] - tmpAngles[1]);
 
     const x = shape.cx;
     const y = shape.cy;
@@ -235,7 +230,7 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
         }
 
         // no inner ring, is a circular sector
-        if (!(innerRadius > e)) {
+        if (!(innerRadius > e) || !(arc > e)) {
             ctx.lineTo(x + xire, y + yire);
         }
         // the inner ring has corners

--- a/test/sector.html
+++ b/test/sector.html
@@ -73,6 +73,22 @@
                 r: 100
             }
         }));
+
+        zr.add(new SectorShape({
+            position: [100, 100],
+            scale: [1, 1],
+            style: {
+                stroke: 'black'
+            },
+            shape: {
+                startAngle: 0,
+                endAngle: 0,
+                r0: 50,
+                r: 100,
+                cornerRadius: 10,
+                innerCornerRadius: 10
+            }
+        }));
     });
     </script>
     <div id="main" style="width:1000px;height:600px;"></div>


### PR DESCRIPTION
When the corner radius is specified but the angle of sector is smaller than `1e-4`, we should not draw the corners.
Otherwise, we will get an unexpected result like the following screenshots.

![image](https://user-images.githubusercontent.com/26999792/97838606-848ba980-1d1b-11eb-99a3-2ddc1a21a244.png)

![image](https://user-images.githubusercontent.com/26999792/97838550-5efea000-1d1b-11eb-8ffb-9195ec206c48.png)

