### PR TITLE
fix: make manually update animation not trigger "frame" callback

### DIFF
--- a/src/animation/Animation.ts
+++ b/src/animation/Animation.ts
@@ -136,7 +136,7 @@ export default class Animation extends Eventful {
         animator.animation = null;
     }
 
-    update(notTriggerStageUpdate?: boolean) {
+    update(notTriggerFrameAndStageUpdate?: boolean) {
         const time = new Date().getTime() - this._pausedTime;
         const delta = time - this._time;
         let clip = this._clipsHead;
@@ -158,15 +158,15 @@ export default class Animation extends Eventful {
 
         this._time = time;
 
-        this.onframe(delta);
+        if (!notTriggerFrameAndStageUpdate) {
+            this.onframe(delta);
 
-        // 'frame' should be triggered before stage, because upper application
-        // depends on the sequence (e.g., echarts-stream and finish
-        // event judge)
-        this.trigger('frame', delta);
+            // 'frame' should be triggered before stage, because upper application
+            // depends on the sequence (e.g., echarts-stream and finish
+            // event judge)
+            this.trigger('frame', delta);
 
-        if (this.stage.update && !notTriggerStageUpdate) {
-            this.stage.update();
+            this.stage.update && this.stage.update();
         }
     }
 


### PR DESCRIPTION
make manually update animation not trigger "frame" callback,
otherwise it make cause dead loop if manual update calling is from one of the "frame" callback.