### PR TITLE
fix(svg/image): fix `opacity` is not working in SVG renderer.

### DIFF
--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -85,6 +85,13 @@ function bindStyle(svgEl: SVGElement, style: TSpanStyleProps, el?: TSpan): void
 function bindStyle(svgEl: SVGElement, style: ImageStyleProps, el?: ZRImage): void
 function bindStyle(svgEl: SVGElement, style: AllStyleOption, el?: Path | TSpan | ZRImage) {
     const opacity = style.opacity == null ? 1 : style.opacity;
+
+    // only set opacity. stroke and fill cannot be applied to svg image
+    if (el instanceof ZRImage) {
+        svgEl.style.opacity = opacity + '';
+        return;
+    }
+
     if (pathHasFill(style)) {
         let fill = style.fill;
         fill = fill === 'transparent' ? NONE : fill;
@@ -348,6 +355,7 @@ const svgImage: SVGProxy<ZRImage> = {
         attr(svgEl, 'x', x + '');
         attr(svgEl, 'y', y + '');
 
+        bindStyle(svgEl, style, el);
         setTransform(svgEl, el.transform);
     }
 };

--- a/test/svg-image-opacity.html
+++ b/test/svg-image-opacity.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Image</title>
+    <script src="./lib/config.js"></script>
+    <script src="../dist/zrender.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+    <div>fix
+        <a href="https://github.com/apache/incubator-echarts/issues/13762" target="_blank">apache/incubator-echarts#13762</a>
+    </div>
+    <div id="main" style="width:1000px;height:800px;"></div>
+    <script type="text/javascript">
+    // initializes zrender
+    var zr = zrender.init(document.getElementById('main'), {
+        renderer: window.__ZRENDER__DEFAULT__RENDERER__ || 'svg'
+    });
+
+    var imageSize = 50;
+    [1, .8, .5, .2, 0].forEach(function(opacity, i) {
+        zr.add(new zrender.Image({
+            position: [i * imageSize, i * imageSize],
+            scale: [1, 1],
+            style: {
+                x: 0,
+                y: 0,
+                image: 'https://echarts.apache.org/zh/images/favicon.png',
+                width: imageSize,
+                height: imageSize,
+                opacity: opacity
+            },
+            textContent: new zrender.Text({
+                style: {
+                    text: `opacity: ${opacity}`,
+                    fontWeight: 'bold',
+                    fontSize: 12
+                }
+            }),
+            textConfig: {
+                position: 'right'
+            },
+            draggable: true
+        }));
+    });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
To fix the bug reported in apache/incubator-echarts#13762. (`opacity` is not working in SVG renderer)

Please refer to `test/svg-image-opacity.html` for the test case.

**Before**

![Before](https://user-images.githubusercontent.com/26999792/101277590-7c2dff00-37f0-11eb-867c-1025d245ecbe.png)

**After**

![After](https://user-images.githubusercontent.com/26999792/101277569-4db02400-37f0-11eb-8cae-666a24f4ab51.png)

