### PR TITLE
fix(image): svg image src may be a canvas element.

### DIFF
--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -324,8 +324,11 @@ const svgImage: SVGProxy<ZRImage> = {
         let image = style.image;
 
         if (image instanceof HTMLImageElement) {
-            const src = image.src;
-            image = src;
+            image = image.src;
+        }
+        // heatmap layer in geo may be a canvas
+        else if (image instanceof HTMLCanvasElement) {
+            image = image.toDataURL();
         }
         if (!image) {
             return;


### PR DESCRIPTION
Related source code in ECharts: http://github.com/apache/incubator-echarts/tree/master/src/chart/heatmap/HeatmapLayer.ts

**The broken heatmap layer**

![image](https://user-images.githubusercontent.com/26999792/103287218-e5ceb100-4a1c-11eb-8e5f-ba8495fea7d9.png)

**After fix**

![image](https://user-images.githubusercontent.com/26999792/103287308-2c241000-4a1d-11eb-8284-ec5f4cc9ddb3.png)


**The related test case can be found in `echarts/test/heatmap-map.html`**