### PR TITLE
fix: remove unexpected imports from exports .

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -7,7 +7,7 @@ import Element from './Element';
 // https://jsfiddle.net/pissang/jr4x7mdm/8/
 import timsort from './core/timsort';
 import Displayable from './graphic/Displayable';
-import { Path } from './export';
+import Path from './graphic/Path';
 
 let invalidZErrorLogged = false;
 function logInvalidZError() {

--- a/src/canvas/Painter.ts
+++ b/src/canvas/Painter.ts
@@ -4,7 +4,6 @@ import Layer, { LayerConfig } from './Layer';
 import requestAnimationFrame from '../animation/requestAnimationFrame';
 import ZRImage from '../graphic/Image';
 import env from '../core/env';
-import { Path, IncrementalDisplayable } from '../export';
 import Displayable from '../graphic/Displayable';
 import { WXCanvasRenderingContext, ZRCanvasRenderingContext } from '../core/types';
 import { GradientObject } from '../graphic/Gradient';
@@ -14,6 +13,8 @@ import { brush, BrushScope, brushSingle } from './graphic';
 import { PainterBase } from '../PainterBase';
 import BoundingRect from '../core/BoundingRect';
 import Element from '../Element';
+import IncrementalDisplayable from '../graphic/IncrementalDisplayable';
+import Path from '../graphic/Path';
 
 const HOVER_LAYER_ZLEVEL = 1e5;
 const CANVAS_ZLEVEL = 314159;
@@ -416,6 +417,7 @@ export default class CanvasPainter implements PainterBase {
                 start = layer.__startIndex;
             }
             let i: number;
+            /* eslint-disable-next-line */
             const repaint = (repaintRect?: BoundingRect) => {
                 const scope: BrushScope = {
                     inHover: false,
@@ -506,7 +508,7 @@ export default class CanvasPainter implements PainterBase {
         };
     }
 
-    private _doPaintEl (
+    private _doPaintEl(
         el: Displayable,
         currentLayer: Layer,
         useDirtyRect: boolean,

--- a/src/canvas/graphic.ts
+++ b/src/canvas/graphic.ts
@@ -5,18 +5,17 @@ import { PatternObject } from '../graphic/Pattern';
 import { LinearGradientObject } from '../graphic/LinearGradient';
 import { RadialGradientObject } from '../graphic/RadialGradient';
 import { ZRCanvasRenderingContext } from '../core/types';
-import BoundingRect from '../core/BoundingRect';
 import { createOrUpdateImage, isImageReady } from '../graphic/helper/image';
 import { getCanvasGradient, isClipPathChanged } from './helper';
 import Path, { PathStyleProps } from '../graphic/Path';
 import ZRImage, { ImageStyleProps } from '../graphic/Image';
 import TSpan, {TSpanStyleProps} from '../graphic/TSpan';
 import { DEFAULT_FONT } from '../contain/text';
-import { IncrementalDisplayable } from '../export';
 import { MatrixArray } from '../core/matrix';
 import { map } from '../core/util';
 import { normalizeLineDash } from '../graphic/helper/dashStyle';
 import Element from '../Element';
+import IncrementalDisplayable from '../graphic/IncrementalDisplayable';
 
 const pathProxyForDraw = new PathProxy(true);
 

--- a/src/graphic/IncrementalDisplayable.ts
+++ b/src/graphic/IncrementalDisplayable.ts
@@ -10,12 +10,12 @@
 import Displayble from './Displayable';
 import BoundingRect from '../core/BoundingRect';
 import { MatrixArray } from '../core/matrix';
-import { Group } from '../export';
+import Group from './Group';
 
 const m: MatrixArray = [];
 // TODO Style override ?
 
-export default class IncrementalDisplayble extends Displayble {
+export default class IncrementalDisplayable extends Displayble {
 
     notClear: boolean = true
 

--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -5,8 +5,7 @@
 import {createElement} from './core';
 import { PathRebuilder } from '../core/PathProxy';
 import * as matrix from '../core/matrix';
-import { Path } from '../export';
-import { PathStyleProps } from '../graphic/Path';
+import Path, { PathStyleProps } from '../graphic/Path';
 import ZRImage, { ImageStyleProps } from '../graphic/Image';
 import { DEFAULT_FONT, getLineHeight } from '../contain/text';
 import TSpan, { TSpanStyleProps } from '../graphic/TSpan';

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -20,13 +20,14 @@ import { Dictionary, ElementEventName } from './core/types';
 import { LayerConfig } from './canvas/Layer';
 import { GradientObject } from './graphic/Gradient';
 import { PatternObject } from './graphic/Pattern';
-import { Path, Group } from './export';
 import { EventCallback } from './core/Eventful';
 import TSpan from './graphic/TSpan';
 import ZRImage from './graphic/Image';
 import Displayable from './graphic/Displayable';
 import { lum } from './tool/color';
 import { DARK_MODE_THRESHOLD } from './config';
+import Path from './graphic/Path';
+import Group from './graphic/Group';
 
 
 const useVML = !env.canvasSupported;


### PR DESCRIPTION
Remove unexpected imports from exports. Which may lead to bundling the whole lib in echarts.