### PR TITLE
fix(config): check if window.screen exists before calculating the dpr.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ let dpr = 1;
 // If in browser environment
 if (typeof window !== 'undefined') {
     dpr = Math.max(window.devicePixelRatio 
-    	|| ((window.screen as any).deviceXDPI / (window.screen as any).logicalXDPI) 
+    	|| (window.screen && (window.screen as any).deviceXDPI / (window.screen as any).logicalXDPI) 
     	|| 1, 1);
 }
 


### PR DESCRIPTION
- enhance ecomfe/zrender#623
-  fix apache/incubator-echarts#13940.

As reported in apache/incubator-echarts#13940, WeChat MiniProgram has no `screen` object in the global `window` object so that it may throw an unexpected error.