### PR TITLE
fix(handler): fix global out not work bug. 

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -232,7 +232,6 @@ class Handler extends Eventful {
 
     mouseout(event: ZRRawEvent) {
         const eventControl = event.zrEventControl;
-        const zrIsToLocalDOM = event.zrIsToLocalDOM;
 
         if (eventControl !== 'only_globalout') {
             this.dispatchToElement(this._hovered, 'mouseout', event);
@@ -241,7 +240,7 @@ class Handler extends Eventful {
         if (eventControl !== 'no_globalout') {
             // FIXME: if the pointer moving from the extra doms to realy "outside",
             // the `globalout` should have been triggered. But currently not.
-            !zrIsToLocalDOM && this.trigger('globalout', {type: 'globalout', event: event});
+            this.trigger('globalout', {type: 'globalout', event: event});
         }
     }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -45,9 +45,6 @@ type ZREventProperties = {
     // 'only_globalout" means: only trigger "globalout" event, but do not
     //     trigger other event to zr user.
     zrEventControl: 'no_globalout' | 'only_globalout'
-    // Means that this event is `mouseout` from `painter.getViewportRoot()`
-    // to other el that `domBelongToZr` is marked as `true`.
-    zrIsToLocalDOM: boolean
 
     zrByTouch: boolean
 }

--- a/src/dom/HandlerProxy.ts
+++ b/src/dom/HandlerProxy.ts
@@ -219,19 +219,7 @@ const localDOMHandlers: DomHandlersMap = {
     },
 
     mouseout(event: ZRRawEvent) {
-        // For SVG rendering, there are SVG elements inside `this.dom`.
-        // (especially in decal case). Should not to handle those "mouseout".
-        if (event.target !== this.dom) {
-            return;
-        }
-
         event = normalizeEvent(this.dom, event);
-
-        // Similarly to the browser did on `document` and touch event,
-        // `globalout` will be delayed to final pointer cature release.
-        if (this.__pointerCapturing) {
-            event.zrEventControl = 'no_globalout';
-        }
 
         // There might be some doms created by upper layer application
         // at the same level of painter.getViewportRoot() (e.g., tooltip
@@ -239,9 +227,18 @@ const localDOMHandlers: DomHandlersMap = {
         // be triggered when mouse enters these doms. (But 'mouseout'
         // should be triggered at the original hovered element as usual).
         const element = (event as any).toElement || (event as ZRRawMouseEvent).relatedTarget;
-        event.zrIsToLocalDOM = isLocalEl(this, element);
 
-        this.trigger('mouseout', event);
+        // For SVG rendering, there are SVG elements inside `this.dom`.
+        // (especially in decal case). Should not to handle those "mouseout"..
+        if (!isLocalEl(this, element)) {
+            // Similarly to the browser did on `document` and touch event,
+            // `globalout` will be delayed to final pointer cature release.
+            if (this.__pointerCapturing) {
+                event.zrEventControl = 'no_globalout';
+            }
+
+            this.trigger('mouseout', event);
+        }
     },
 
     wheel(event: ZRRawEvent) {


### PR DESCRIPTION
fix https://github.com/apache/incubator-echarts/issues/13958

### Why this bug happens:

This bug is brought when fixing the wrong `mouseout` event triggered in SVG renderer in https://github.com/ecomfe/zrender/compare/fix-global-out?expand=1#diff-619a90e06ad2f3966dac739e2d1fb17006d9f44978316c758d694a40cde28201L222

But in canvas renderer, the `event.target` will is the canvas element when mouseout. Not the viewport. So the `globalout` will never be triggered.

### Fix:

Determine if the target element is a descendant of the viewport. If so, both `mouseout` and `globalout` event won't be triggered.
