### PR TITLE
fix(svg): remove redundant declarations.

### DIFF
--- a/src/PainterBase.ts
+++ b/src/PainterBase.ts
@@ -21,7 +21,6 @@ export interface PainterBase {
     refresh(): void
     clear(): void
 
-    getViewportRoot(): HTMLElement
     getType: () => string
 
     getWidth(): number

--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -278,7 +278,7 @@ class SVGPainter implements PainterBase {
         let currentClipGroup;
         for (let i = 0; i < diff.length; i++) {
             const item = diff[i];
-            const isAdd = item.added;
+            // const isAdd = item.added;
             if (item.removed) {
                 continue;
             }

--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -21,9 +21,7 @@ import {
 } from './graphic';
 import Displayable from '../graphic/Displayable';
 import Storage from '../Storage';
-import { GradientObject } from '../graphic/Gradient';
 import { PainterBase } from '../PainterBase';
-import {PatternObject} from '../graphic/Pattern';
 
 function parseInt10(val: string) {
     return parseInt(val, 10);

--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -223,7 +223,7 @@ class SVGPathRebuilder implements PathRebuilder {
         const x = round4(cx + rx * mathCos(startAngle + dTheta));
         const y = round4(cy + ry * mathSin(startAngle + dTheta));
 
-        if (isNaN(x0) || isNaN(y0) || isNaN(rx) || isNaN(ry) || isNaN(psi) || isNaN(degree) || isNaN(x)  || isNaN(y)) {
+        if (isNaN(x0) || isNaN(y0) || isNaN(rx) || isNaN(ry) || isNaN(psi) || isNaN(degree) || isNaN(x) || isNaN(y)) {
             return '';
         }
 

--- a/src/svg/helper/PatternManager.ts
+++ b/src/svg/helper/PatternManager.ts
@@ -219,7 +219,7 @@ export default class PatternManager extends Definable {
 }
 
 
-const patternSizeCache = new LRU<CachedImageObj>(50);
+// const patternSizeCache = new LRU<CachedImageObj>(50);
 
 type CachedImageObj = {
     width: number,

--- a/src/svg/helper/PatternManager.ts
+++ b/src/svg/helper/PatternManager.ts
@@ -7,7 +7,6 @@ import Definable from './Definable';
 import * as zrUtil from '../../core/util';
 import Displayable from '../../graphic/Displayable';
 import {PatternObject} from '../../graphic/Pattern';
-// import LRU from '../../core/LRU';
 import {createOrUpdateImage} from '../../graphic/helper/image';
 import WeakMap from '../../core/WeakMap';
 
@@ -217,9 +216,6 @@ export default class PatternManager extends Definable {
     }
 
 }
-
-
-// const patternSizeCache = new LRU<CachedImageObj>(50);
 
 type CachedImageObj = {
     width: number,

--- a/src/svg/helper/PatternManager.ts
+++ b/src/svg/helper/PatternManager.ts
@@ -7,7 +7,7 @@ import Definable from './Definable';
 import * as zrUtil from '../../core/util';
 import Displayable from '../../graphic/Displayable';
 import {PatternObject} from '../../graphic/Pattern';
-import LRU from '../../core/LRU';
+// import LRU from '../../core/LRU';
 import {createOrUpdateImage} from '../../graphic/helper/image';
 import WeakMap from '../../core/WeakMap';
 

--- a/src/svg/helper/ShadowManager.ts
+++ b/src/svg/helper/ShadowManager.ts
@@ -7,8 +7,6 @@ import Definable from './Definable';
 import Displayable from '../../graphic/Displayable';
 import { PathStyleProps } from '../../graphic/Path';
 import { Dictionary } from '../../core/types';
-import { each } from '../../core/util';
-
 
 type DisplayableExtended = Displayable & {
     _shadowDom: SVGElement
@@ -135,11 +133,11 @@ export default class ShadowManager extends Definable {
         }
         let shadowDomsPool = this._shadowDomPool;
 
-        let currentUsedShadow = 0;
+        // let currentUsedShadow = 0;
         for (let key in this._shadowDomMap) {
             const dom = this._shadowDomMap[key];
             shadowDomsPool.push(dom);
-            currentUsedShadow++;
+            // currentUsedShadow++;
         }
 
         // Reset the map.


### PR DESCRIPTION
(1) The declaration of method `getViewportRoot` in https://github.com/ecomfe/zrender/blob/master/src/PainterBase.ts#L24 is the same as https://github.com/ecomfe/zrender/blob/master/src/PainterBase.ts#L31

It may have been unexpectedly brought in the merging process. So removed it.

(2) remove/comment some other redundant or unused variables and imports.