### PR TITLE
fix(env): fix potential NPE in `env.canvasSupported`.

### DIFF
--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -81,7 +81,7 @@ function detect(ua: string, env: Env) {
         browser.weChat = true;
     }
 
-    env.canvasSupported = !!document.createElement('canvas').getContext;
+    env.canvasSupported = !!(document && document.createElement('canvas').getContext);
     env.svgSupported = typeof SVGRect !== 'undefined';
     env.touchEventsSupported = 'ontouchstart' in window && !browser.ie && !browser.edge;
     env.pointerEventsSupported = 'onpointerdown' in window


### PR DESCRIPTION
if 
```js
env.domSupported = typeof document !== 'undefined';
```
is `false`, then `document` may be null, this will bring a NPE by 
```js
env.canvasSupported = !!document.createElement('canvas').getContext
```

UPDATE: It seems that `document` will never be undefined here?