### PR TITLE
fix(render): fix illegal opacity may lead to opacity leak.

### DIFF
--- a/src/canvas/graphic.ts
+++ b/src/canvas/graphic.ts
@@ -402,7 +402,9 @@ function bindCommonProps(
             flushPathDrawn(ctx, scope);
             styleChanged = true;
         }
-        ctx.globalAlpha = style.opacity == null ? DEFAULT_COMMON_STYLE.opacity : style.opacity;
+        // Ensure opacity is between 0 ~ 1. Invalid opacity will lead to a failure set and use the leaked opacity from the previous.
+        const opacity = Math.max(Math.min(style.opacity, 1), 0);
+        ctx.globalAlpha = isNaN(opacity) ? DEFAULT_COMMON_STYLE.opacity : opacity;
     }
 
     if (forceSetAll || style.blend !== prevStyle.blend) {

--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -289,6 +289,7 @@ class ZRText extends Displayable<TextProps> {
             this._updateSubTexts();
         }
 
+
         for (let i = 0; i < this._children.length; i++) {
             const child = this._children[i];
             // Set common properties.


### PR DESCRIPTION
If we set an invalid value on `ctx.globalAlpha`. It will take no effect and keep the previous value, which will cause `opacity` value leaks between displayables.

In some cases of ECharts. The value will exceed the range `0 ~ 1`, which usually happens when using `visualMap`. It's also invalid and a better and more intuitive way is to clamp the value to `0 ~ 1`