### PR TITLE
chore: add nightly build action to workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,29 @@
+name: Publish Nightly
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  repository_dispatch:
+    types: publish-nightly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          registry-url: https://registry.npmjs.org/
+      - name: Setup and publish nightly
+        run: |
+          npm run release
+          npm run prepare:nightly
+          npm publish --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/build/build.js
+++ b/build/build.js
@@ -5,7 +5,7 @@ const path = require('path');
 const processs = require('process');
 const chalk = require('chalk');
 const progress = require('./progress');
-const UglifyJS = require("uglify-js");
+const UglifyJS = require('uglify-js');
 const fs = require('fs');
 
 function current() {

--- a/build/prepareNightly.js
+++ b/build/prepareNightly.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const packageJsonPath = __dirname + '/../package.json';
+const nightlyPackageName = 'zrender-nightly';
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const version = packageJson.version;
+const parts = /(\d+)\.(\d+)\.(\d+)($|\-)/.exec(version);
+if (!parts) {
+    throw new Error(`Invalid version number ${version}`);
+}
+// Add date to version.
+const major = parts[1];
+const minor = parts[2];
+const patch = parts[3];
+
+const date = new Date().toISOString().replace(/:|T|\.|-/g, '').slice(0, 8);
+const nightlyVersion = `${major}.${minor}.${patch}-dev.${date}`;
+
+packageJson.name = nightlyPackageName;
+packageJson.version = nightlyVersion;
+
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf-8');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepublish": "npm run release",
     "build": "npm run build:bundle && npm run build:lib",
     "release": "node build/build.js --minify && npm run build:lib",
+    "prepare:nightly": "node build/prepareNightly.js",
     "build:bundle": "node build/build.js",
     "build:lib": "npx tsc -m ES2015 --outDir lib",
     "watch:bundle": "node build/build.js --watch",


### PR DESCRIPTION
It will publish a dev version in format `5.0.4-dev.2021.04.16` from master  to `zrender-nightly@dev` at 08:00 UTC every day.