### PR TITLE
fix(BoundingRect): don't check if the width and height is finite in constructor.

### DIFF
--- a/src/core/BoundingRect.ts
+++ b/src/core/BoundingRect.ts
@@ -24,11 +24,11 @@ class BoundingRect {
     height: number
 
     constructor(x: number, y: number, width: number, height: number) {
-        if (width < 0 && isFinite(width)) {
+        if (width < 0) {
             x = x + width;
             width = -width;
         }
-        if (height < 0 && isFinite(height)) {
+        if (height < 0) {
             y = y + height;
             height = -height;
         }


### PR DESCRIPTION
fix apache/echarts#14534

**PENDING:**
It seems `Infinity` cannot be simply considered as `0`, after all, it's infinitely large but not zero.

And I saw the `BoundingRect#union` is checking if the value is finite, which indicates the infinite values can exist in the constructed instance of `BoundingRect`, so I'm thinking the no check need to do in the constructor.