### PR TITLE
chore: increase dev version from stable version.

### DIFF
--- a/build/prepareNightly.js
+++ b/build/prepareNightly.js
@@ -9,9 +9,14 @@ if (!parts) {
     throw new Error(`Invalid version number ${version}`);
 }
 // Add date to version.
-const major = parts[1];
-const minor = parts[2];
-const patch = parts[3];
+const major = +parts[1];
+const minor = +parts[2];
+let patch = +parts[3];
+const isStable = !parts[4];
+if (isStable) {
+    // It's previous stable version. Dev version should be higher.
+    patch++;
+}
 
 const date = new Date().toISOString().replace(/:|T|\.|-/g, '').slice(0, 8);
 const nightlyVersion = `${major}.${minor}.${patch}-dev.${date}`;


### PR DESCRIPTION
Previously the major, minor, and patch in the dev version are the same as the last stable version, which is wrong in semver. So this PR increases the patch version automatically when publishing the dev version. For example, the current stable version is `5.1.0`. Then the dev version will be `5.1.1-dev.20210420`. It's not fully correct because the next stable version maybe 5.2.0. But I think it won't have any bad effect.