### PR TITLE
chore: use latest tag in zrender-nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -25,6 +25,6 @@ jobs:
           npm ci
           npm run release
           npm run prepare:nightly
-          npm publish --tag dev
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Use the latest tag instead of dev in zrender-nightly or if it's always being the first published version