### PR TITLE
fix some bugs in progressive rendering.

### DIFF
--- a/src/Element.ts
+++ b/src/Element.ts
@@ -28,6 +28,7 @@ import Point from './core/Point';
 import { LIGHT_LABEL_COLOR, DARK_LABEL_COLOR } from './config';
 import { parse, stringify } from './tool/color';
 import env from './core/env';
+import { REDARAW_BIT, STYLE_CHANGED_BIT } from './graphic/constants';
 
 export interface ElementAnimateConfig {
     duration?: number
@@ -658,13 +659,14 @@ class Element<Props extends ElementProps = ElementProps> {
                 textEl.setDefaultTextStyle(innerTextDefaultStyle);
             }
 
+            // Mark textEl to update transform.
+            // DON'T use markRedraw. It will cause Element itself to dirty again.
+            textEl.__dirty &= REDARAW_BIT;
+
             if (textStyleChanged) {
                 // Only mark style dirty if necessary. Update ZRText is costly.
-                textEl.dirtyStyle();
+                textEl.__dirty &= STYLE_CHANGED_BIT;
             }
-
-            // Mark textEl to update transform.
-            textEl.markRedraw();
         }
     }
 
@@ -850,7 +852,7 @@ class Element<Props extends ElementProps = ElementProps> {
      * @param keepCurrentState If keep current states.
      *      If not, it will inherit from the normal state.
      */
-    useState(stateName: string, keepCurrentStates?: boolean, noAnimation?: boolean) {
+    useState(stateName: string, keepCurrentStates?: boolean, noAnimation?: boolean, forceUseHoverLayer?: boolean) {
         // Use preserved word __normal__
         // TODO: Only restore changed properties when restore to normal???
         const toNormalState = stateName === PRESERVED_NORMAL_STATE;
@@ -889,7 +891,7 @@ class Element<Props extends ElementProps = ElementProps> {
             this.saveCurrentToNormalState(state);
         }
 
-        const useHoverLayer = !!(state && state.hoverLayer);
+        const useHoverLayer = !!((state && state.hoverLayer) || forceUseHoverLayer);
 
         if (useHoverLayer) {
             // Enter hover layer before states update.
@@ -906,11 +908,14 @@ class Element<Props extends ElementProps = ElementProps> {
         );
 
         // Also set text content.
-        if (this._textContent) {
-            this._textContent.useState(stateName, keepCurrentStates);
+        const textContent = this._textContent;
+        const textGuide = this._textGuide;
+        if (textContent) {
+            // Force textContent use hover layer if self is using it.
+            textContent.useState(stateName, keepCurrentStates, noAnimation, useHoverLayer);
         }
-        if (this._textGuide) {
-            this._textGuide.useState(stateName, keepCurrentStates);
+        if (textGuide) {
+            textGuide.useState(stateName, keepCurrentStates, noAnimation, useHoverLayer);
         }
 
         if (toNormalState) {
@@ -938,7 +943,7 @@ class Element<Props extends ElementProps = ElementProps> {
             this._toggleHoverLayerFlag(false);
             // NOTE: avoid unexpected refresh when moving out from hover layer!!
             // Only clear from hover layer.
-            this.__dirty &= ~Element.REDARAW_BIT;
+            this.__dirty &= ~REDARAW_BIT;
         }
 
         // Return used state.
@@ -949,7 +954,7 @@ class Element<Props extends ElementProps = ElementProps> {
      * Apply multiple states.
      * @param states States list.
      */
-    useStates(states: string[], noAnimation?: boolean) {
+    useStates(states: string[], noAnimation?: boolean, forceUseHoverLayer?: boolean) {
         if (!states.length) {
             this.clearStates();
         }
@@ -984,7 +989,8 @@ class Element<Props extends ElementProps = ElementProps> {
                 }
             }
 
-            const useHoverLayer = !!(stateObjects[len - 1] && stateObjects[len - 1].hoverLayer);
+            const lastStateObj = stateObjects[len - 1];
+            const useHoverLayer = !!((lastStateObj && lastStateObj.hoverLayer) || forceUseHoverLayer);
             if (useHoverLayer) {
                 // Enter hover layer before states update.
                 this._toggleHoverLayerFlag(true);
@@ -1004,11 +1010,13 @@ class Element<Props extends ElementProps = ElementProps> {
                 animationCfg
             );
 
-            if (this._textContent) {
-                this._textContent.useStates(states);
+            const textContent = this._textContent;
+            const textGuide = this._textGuide;
+            if (textContent) {
+                textContent.useStates(states, noAnimation, useHoverLayer);
             }
-            if (this._textGuide) {
-                this._textGuide.useStates(states);
+            if (textGuide) {
+                textGuide.useStates(states, noAnimation, useHoverLayer);
             }
 
             this._updateAnimationTargets();
@@ -1022,7 +1030,7 @@ class Element<Props extends ElementProps = ElementProps> {
                 this._toggleHoverLayerFlag(false);
                 // NOTE: avoid unexpected refresh when moving out from hover layer!!
                 // Only clear from hover layer.
-                this.__dirty &= ~Element.REDARAW_BIT;
+                this.__dirty &= ~REDARAW_BIT;
             }
         }
     }
@@ -1352,7 +1360,7 @@ class Element<Props extends ElementProps = ElementProps> {
      * Mark element needs to be repainted
      */
     markRedraw() {
-        this.__dirty |= Element.REDARAW_BIT;
+        this.__dirty |= REDARAW_BIT;
         const zr = this.__zr;
         if (zr) {
             if (this.__inHover) {
@@ -1604,9 +1612,6 @@ class Element<Props extends ElementProps = ElementProps> {
         out: TextPositionCalculationResult, style: ElementTextConfig, rect: RectLike
     ) => TextPositionCalculationResult
 
-
-    static REDARAW_BIT = 1;
-
     protected static initDefaultProps = (function () {
         const elProto = Element.prototype;
         elProto.type = 'element';
@@ -1618,7 +1623,7 @@ class Element<Props extends ElementProps = ElementProps> {
         elProto.dragging = false;
         elProto.ignoreClip = false;
         elProto.__inHover = false;
-        elProto.__dirty = Element.REDARAW_BIT;
+        elProto.__dirty = REDARAW_BIT;
 
 
         const logs: Dictionary<boolean> = {};

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -8,6 +8,7 @@ import Element from './Element';
 import timsort from './core/timsort';
 import Displayable from './graphic/Displayable';
 import Path from './graphic/Path';
+import { REDARAW_BIT } from './graphic/constants';
 
 let invalidZErrorLogged = false;
 function logInvalidZError() {
@@ -140,7 +141,7 @@ export default class Storage {
 
                 // Force to mark as dirty if group is dirty
                 if (el.__dirty) {
-                    child.__dirty |= Element.REDARAW_BIT;
+                    child.__dirty |= REDARAW_BIT;
                 }
 
                 this._updateAndAddDisplayable(child, clipPaths, includeIgnore);

--- a/src/canvas/Layer.ts
+++ b/src/canvas/Layer.ts
@@ -10,6 +10,7 @@ import { getCanvasGradient } from './helper';
 import { createCanvasPattern } from './graphic';
 import Displayable from '../graphic/Displayable';
 import BoundingRect from '../core/BoundingRect';
+import { REDARAW_BIT } from '../graphic/constants';
 
 function returnFalse() {
     return false;
@@ -280,7 +281,7 @@ export default class Layer extends Eventful {
                  * or not painted this frame.
                  */
                 const shouldPaint = el.shouldBePainted(viewWidth, viewHeight, true, true);
-                const prevRect = el.__isRendered && ((el.__dirty & Element.REDARAW_BIT) || !shouldPaint)
+                const prevRect = el.__isRendered && ((el.__dirty & REDARAW_BIT) || !shouldPaint)
                     ? el.getPrevPaintRect()
                     : null;
                 if (prevRect) {
@@ -292,7 +293,7 @@ export default class Layer extends Eventful {
                  * if the element should be brushed this frame and either being
                  * dirty or not rendered before.
                  */
-                const curRect = shouldPaint && ((el.__dirty & Element.REDARAW_BIT) || !el.__isRendered)
+                const curRect = shouldPaint && ((el.__dirty & REDARAW_BIT) || !el.__isRendered)
                     ? el.getPaintRect()
                     : null;
                 if (curRect) {

--- a/src/canvas/Painter.ts
+++ b/src/canvas/Painter.ts
@@ -15,6 +15,7 @@ import BoundingRect from '../core/BoundingRect';
 import Element from '../Element';
 import IncrementalDisplayable from '../graphic/IncrementalDisplayable';
 import Path from '../graphic/Path';
+import { REDARAW_BIT } from '../graphic/constants';
 
 const HOVER_LAYER_ZLEVEL = 1e5;
 const CANVAS_ZLEVEL = 314159;
@@ -402,6 +403,7 @@ export default class CanvasPainter implements PainterBase {
 
             const clearColor = layer.zlevel === this._zlevelList[0]
                 ? this._backgroundColor : null;
+
             // All elements in this layer are cleared.
             if (layer.__startIndex === layer.__endIndex) {
                 layer.clear(false, clearColor, repaintRects);
@@ -700,6 +702,7 @@ export default class CanvasPainter implements PainterBase {
         let incrementalLayerCount = 0;
         let prevZlevel;
         let i;
+
         for (i = 0; i < list.length; i++) {
             const el = list[i];
             const zlevel = el.zlevel;
@@ -751,7 +754,7 @@ export default class CanvasPainter implements PainterBase {
                 updatePrevLayer(i);
                 prevLayer = layer;
             }
-            if ((el.__dirty & Element.REDARAW_BIT) && !el.__inHover) {  // Ignore dirty elements in hover layer.
+            if ((el.__dirty & REDARAW_BIT) && !el.__inHover) {  // Ignore dirty elements in hover layer.
                 layer.__dirty = true;
                 if (layer.incremental && layer.__drawIndex < 0) {
                     // Start draw from the first dirty element.

--- a/src/canvas/graphic.ts
+++ b/src/canvas/graphic.ts
@@ -16,6 +16,7 @@ import { map } from '../core/util';
 import { normalizeLineDash } from '../graphic/helper/dashStyle';
 import Element from '../Element';
 import IncrementalDisplayable from '../graphic/IncrementalDisplayable';
+import { REDARAW_BIT, SHAPE_CHANGED_BIT } from '../graphic/constants';
 
 const pathProxyForDraw = new PathProxy(true);
 
@@ -196,7 +197,7 @@ function brushPath(ctx: CanvasRenderingContext2D, el: Path, style: PathStyleProp
     // 1. Path is dirty
     // 2. Path needs javascript implemented lineDash stroking.
     //    In this case, lineDash information will not be saved in PathProxy
-    if (firstDraw || (el.__dirty & Path.SHAPE_CHANGED_BIT)
+    if (firstDraw || (el.__dirty & SHAPE_CHANGED_BIT)
         || (lineDash && !ctxLineDash && hasStroke)
     ) {
         path.setDPR((ctx as any).dpr);
@@ -640,7 +641,7 @@ export function brush(
         // Or this element will always been rendered in progressive rendering.
         // But other dirty bit should not be cleared, otherwise it cause the shape
         // can not be updated in this case.
-        el.__dirty &= ~Element.REDARAW_BIT;
+        el.__dirty &= ~REDARAW_BIT;
         el.__isRendered = false;
         return;
     }

--- a/src/graphic/Displayable.ts
+++ b/src/graphic/Displayable.ts
@@ -1,6 +1,5 @@
 /**
  * Base class of all displayable graphic objects
- * @module zrender/graphic/Displayable
  */
 
 import Element, {ElementProps, ElementStatePropNames, ElementAnimateConfig, ElementCommonState} from '../Element';
@@ -9,6 +8,7 @@ import { PropType, Dictionary, MapToType } from '../core/types';
 import Path from './Path';
 import { keys, extend, createObject } from '../core/util';
 import Animator from '../animation/Animator';
+import { REDARAW_BIT, STYLE_CHANGED_BIT } from './constants';
 
 // type CalculateTextPositionResult = ReturnType<typeof calculateTextPosition>
 
@@ -77,6 +77,7 @@ export type DisplayableStatePropNames = ElementStatePropNames | 'style' | 'z' | 
 export type DisplayableState = Pick<DisplayableProps, DisplayableStatePropNames> & ElementCommonState;
 
 const PRIMARY_STATES_KEYS = ['z', 'z2', 'invisible'] as const;
+const PRIMARY_STATES_KEYS_IN_HOVER_LAYER = ['invisible'] as const;
 
 interface Displayable<Props extends DisplayableProps = DisplayableProps> {
     animate(key?: '', loop?: boolean): Animator<this>
@@ -363,7 +364,7 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
 
     dirtyStyle() {
         this.markRedraw();
-        this.__dirty |= Displayable.STYLE_CHANGED_BIT;
+        this.__dirty |= STYLE_CHANGED_BIT;
         // Clear bounding rect.
         if (this._rect) {
             this._rect = null;
@@ -378,14 +379,14 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
      * Is style changed. Used with dirtyStyle.
      */
     styleChanged() {
-        return !!(this.__dirty & Displayable.STYLE_CHANGED_BIT);
+        return !!(this.__dirty & STYLE_CHANGED_BIT);
     }
 
     /**
      * Mark style updated. Only useful when style is used for caching. Like in the text.
      */
     styleUpdated() {
-        this.__dirty &= ~Displayable.STYLE_CHANGED_BIT;
+        this.__dirty &= ~STYLE_CHANGED_BIT;
     }
 
     /**
@@ -513,8 +514,11 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
             }
         }
 
-        for (let i = 0; i < PRIMARY_STATES_KEYS.length; i++) {
-            let key = PRIMARY_STATES_KEYS[i];
+        // Don't change z, z2 for element moved into hover layer.
+        // It's not necessary and will cause paint list order changed.
+        const statesKeys = this.__inHover ? PRIMARY_STATES_KEYS_IN_HOVER_LAYER : PRIMARY_STATES_KEYS;
+        for (let i = 0; i < statesKeys.length; i++) {
+            let key = statesKeys[i];
             if (state && state[key] != null) {
                 // Replace if it exist in target state
                 (this as any)[key] = state[key];
@@ -577,8 +581,6 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
      */
     // calculateTextPosition: (out: CalculateTextPositionResult, style: Dictionary<any>, rect: RectLike) => CalculateTextPositionResult
 
-    static STYLE_CHANGED_BIT = 2
-
     protected static initDefaultProps = (function () {
         const dispProto = Displayable.prototype;
         dispProto.type = 'displayable';
@@ -593,7 +595,7 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
         dispProto._rect = null;
         dispProto.dirtyRectTolerance = 0;
 
-        dispProto.__dirty = Element.REDARAW_BIT | Displayable.STYLE_CHANGED_BIT;
+        dispProto.__dirty = REDARAW_BIT | STYLE_CHANGED_BIT;
     })()
 }
 

--- a/src/graphic/Path.ts
+++ b/src/graphic/Path.ts
@@ -16,6 +16,7 @@ import { defaults, keys, extend, clone, isString, createObject } from '../core/u
 import Animator from '../animation/Animator';
 import { lum } from '../tool/color';
 import { DARK_LABEL_COLOR, LIGHT_LABEL_COLOR, DARK_MODE_THRESHOLD, LIGHTER_LABEL_COLOR } from '../config';
+import { REDARAW_BIT, SHAPE_CHANGED_BIT, STYLE_CHANGED_BIT } from './constants';
 
 
 export interface PathStyleProps extends CommonStyleProps {
@@ -166,8 +167,7 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
 
         const style = this.style;
         if (style.decal) {
-            const decalEl: Path = this._decalEl
-                = this._decalEl || new Path();
+            const decalEl: Path = this._decalEl = this._decalEl || new Path();
             if (decalEl.buildPath === Path.prototype.buildPath) {
                 decalEl.buildPath = ctx => {
                     this.buildPath(ctx, this.shape);
@@ -192,7 +192,7 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
                 (decalEl as any)[pathCopyParams[i]] = this[pathCopyParams[i]];
             }
 
-            decalEl.__dirty |= Element.REDARAW_BIT;
+            decalEl.__dirty |= REDARAW_BIT;
         }
         else if (this._decalEl) {
             this._decalEl = null;
@@ -306,7 +306,7 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
     ) {}
 
     pathUpdated() {
-        this.__dirty &= ~Path.SHAPE_CHANGED_BIT;
+        this.__dirty &= ~SHAPE_CHANGED_BIT;
     }
 
     createPathProxy() {
@@ -337,7 +337,7 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
                 this.createPathProxy();
             }
             let path = this.path;
-            if (firstInvoke || (this.__dirty & Path.SHAPE_CHANGED_BIT)) {
+            if (firstInvoke || (this.__dirty & SHAPE_CHANGED_BIT)) {
                 path.beginPath();
                 this.buildPath(path, this.shape, false);
                 this.pathUpdated();
@@ -416,7 +416,7 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
      * Shape changed
      */
     dirtyShape() {
-        this.__dirty |= Path.SHAPE_CHANGED_BIT;
+        this.__dirty |= SHAPE_CHANGED_BIT;
         if (this._rect) {
             this._rect = null;
         }
@@ -486,7 +486,7 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
      * If shape changed. used with dirtyShape
      */
     shapeChanged() {
-        return !!(this.__dirty & Path.SHAPE_CHANGED_BIT);
+        return !!(this.__dirty & SHAPE_CHANGED_BIT);
     }
 
     /**
@@ -654,8 +654,6 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
         return Sub as any;
     }
 
-    static SHAPE_CHANGED_BIT = 4
-
     protected static initDefaultProps = (function () {
         const pathProto = Path.prototype;
         pathProto.type = 'path';
@@ -663,7 +661,7 @@ class Path<Props extends PathProps = PathProps> extends Displayable<Props> {
         pathProto.segmentIgnoreThreshold = 0;
         pathProto.subPixelOptimize = false;
         pathProto.autoBatch = false;
-        pathProto.__dirty = Element.REDARAW_BIT | Displayable.STYLE_CHANGED_BIT | Path.SHAPE_CHANGED_BIT;
+        pathProto.__dirty = REDARAW_BIT | STYLE_CHANGED_BIT | SHAPE_CHANGED_BIT;
     })()
 }
 

--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -12,7 +12,6 @@ import Rect from './shape/Rect';
 import BoundingRect from '../core/BoundingRect';
 import { MatrixArray, copy } from '../core/matrix';
 import Displayable, { DisplayableStatePropNames, DisplayableProps, DEFAULT_COMMON_ANIMATION_PROPS } from './Displayable';
-import Path from './Path';
 import { ZRenderType } from '../zrender';
 import Animator from '../animation/Animator';
 import Transformable from '../core/Transformable';

--- a/src/graphic/constants.ts
+++ b/src/graphic/constants.ts
@@ -1,0 +1,4 @@
+// Bit masks to check which parts of element needs to be updated.
+export const REDARAW_BIT = 1;
+export const STYLE_CHANGED_BIT = 2;
+export const SHAPE_CHANGED_BIT = 4;


### PR DESCRIPTION
1. Attached text will mark the host dirty again during render.
2. Attached text should use the hover layer if its host is using it.
3. Should not change z and z2 of element moved to hover layer, which is not necessary and will cause paint list order changed.