### PR TITLE
chore: add workflow dispatch

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,6 +3,7 @@ name: Publish Nightly
 on:
   schedule:
     - cron: '0 8 * * *'
+  workflow_dispatch: {}
   repository_dispatch:
     types: publish-nightly
 


### PR DESCRIPTION
add workflow dispatch to publish nightly build if it fails.