### PR TITLE
[PENDING] fix(svg): use `textBaseline` specified in text style instead of fixed default value.

### DIFF
--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -414,13 +414,13 @@ const svgText: SVGProxy<TSpan> = {
         setTransform(textSvgEl, el.transform);
 
         // Consider different font display differently in vertial align, we always
-        // set vertialAlign as 'middle', and use 'y' to locate text vertically.
+        // set verticalAlign as 'middle', and use 'y' to locate text vertically.
         const x = style.x || 0;
         const y = adjustTextY(style.y || 0, getLineHeight(font), style.textBaseline);
         const textAlign = TEXT_ALIGN_TO_ANCHOR[style.textAlign as keyof typeof TEXT_ALIGN_TO_ANCHOR]
             || style.textAlign;
 
-        attr(textSvgEl, 'dominant-baseline', 'central');
+        attr(textSvgEl, 'dominant-baseline', style.textBaseline || 'central');
         attr(textSvgEl, 'text-anchor', textAlign);
         attr(textSvgEl, 'x', x + '');
         attr(textSvgEl, 'y', y + '');


### PR DESCRIPTION
**THIS IS A PENDING CHANGE**

I noticed the text node's position rendered by the SVG renderer currently differs from the canvas renderer.

Here are some cases,

<img src="https://user-images.githubusercontent.com/26999792/119218623-ec68dc80-bb13-11eb-97d9-9324e929460a.gif" width="400">

<img src="https://user-images.githubusercontent.com/26999792/119218594-bb88a780-bb13-11eb-8586-2be59194df89.gif" width="400">

<img src="https://user-images.githubusercontent.com/26999792/119218682-3b167680-bb14-11eb-9ef6-6bd25b65f538.gif" width="400">

I'm not sure about the reason for setting the `dominant-baseline` attribute of the text node as a fixed `middle`(previously) or `central`(currently) in SVG renderer, but if we use `textBaseline` specified in text style, it will render the text as the same as the canvas renderer. At least, it will look quite obviously better than now.

