### PR TITLE
fix(svg): fix rect path can't be closed bug & normalize color when using SVG renderer to support more cases.

### DIFF
--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -3,7 +3,7 @@
  * @module zrender/svg/Painter
  */
 
-import {createElement} from './core';
+import {createElement, normalizeColor} from './core';
 import * as util from '../core/util';
 import Path from '../graphic/Path';
 import ZRImage from '../graphic/Image';
@@ -194,7 +194,10 @@ class SVGPainter implements PainterBase {
         bgNode.setAttribute('x', 0 as any);
         bgNode.setAttribute('y', 0 as any);
         bgNode.setAttribute('id', 0 as any);
-        bgNode.style.fill = backgroundColor;
+        const { color, opacity } = normalizeColor(backgroundColor);
+        bgNode.setAttribute('fill', color);
+        bgNode.setAttribute('fill-opacity', opacity as any);
+
         this._backgroundRoot.appendChild(bgNode);
         this._backgroundNode = bgNode;
     }

--- a/src/svg/core.ts
+++ b/src/svg/core.ts
@@ -1,3 +1,23 @@
+import { parse } from '../tool/color'
+
 export function createElement(name: string) {
     return document.createElementNS('http://www.w3.org/2000/svg', name);
+}
+
+export function normalizeColor(color: string): { color: string, opacity: number } {
+    let opacity;
+    if (!color || color === 'transparent') {
+        color = 'none';
+    }
+    else if (color.indexOf('rgba') > -1) {
+        const arr = parse(color);
+        if (arr) {
+            color = 'rgb(' + arr[0] + ',' + arr[1] + ',' + arr[2] + ')';
+            opacity = arr[3];
+        }
+    }
+    return {
+        color,
+        opacity: opacity == null ? 1 : opacity
+    };
 }

--- a/src/svg/core.ts
+++ b/src/svg/core.ts
@@ -1,4 +1,4 @@
-import { parse } from '../tool/color'
+import { parse } from '../tool/color';
 
 export function createElement(name: string) {
     return document.createElementNS('http://www.w3.org/2000/svg', name);

--- a/src/svg/helper/ClippathManager.ts
+++ b/src/svg/helper/ClippathManager.ts
@@ -44,8 +44,11 @@ export default class ClippathManager extends Definable {
 
     markAllUnused() {
         super.markAllUnused();
-        for (let key in this._refGroups) {
-            this.markDomUnused(this._refGroups[key]);
+        const refGroups = this._refGroups;
+        for (let key in refGroups) {
+            if (refGroups.hasOwnProperty(key)) {
+                this.markDomUnused(refGroups[key]);
+            }
         }
         this._keyDuplicateCount = {};
     }
@@ -163,13 +166,16 @@ export default class ClippathManager extends Definable {
         super.removeUnused();
 
         const newRefGroupsMap: Dictionary<SVGElement> = {};
-        for (let key in this._refGroups) {
-            const group = this._refGroups[key];
-            if (!this.isDomUnused(group)) {
-                newRefGroupsMap[key] = group;
-            }
-            else if (group.parentNode) {
-                group.parentNode.removeChild(group);
+        const refGroups = this._refGroups;
+        for (let key in refGroups) {
+            if (refGroups.hasOwnProperty(key)) {
+                const group = refGroups[key];
+                if (!this.isDomUnused(group)) {
+                    newRefGroupsMap[key] = group;
+                }
+                else if (group.parentNode) {
+                    group.parentNode.removeChild(group);
+                }
             }
         }
         this._refGroups = newRefGroupsMap;

--- a/src/svg/helper/ShadowManager.ts
+++ b/src/svg/helper/ShadowManager.ts
@@ -7,6 +7,7 @@ import Definable from './Definable';
 import Displayable from '../../graphic/Displayable';
 import { PathStyleProps } from '../../graphic/Path';
 import { Dictionary } from '../../core/types';
+import { normalizeColor } from '../core';
 
 type DisplayableExtended = Displayable & {
     _shadowDom: SVGElement
@@ -35,7 +36,7 @@ export default class ShadowManager extends Definable {
         if (!shadowDom) {
             shadowDom = this.createElement('filter') as SVGFilterElement;
             shadowDom.setAttribute('id', 'zr' + this._zrId + '-shadow-' + this.nextId++);
-            const domChild = this.createElement('feDropShadow')
+            const domChild = this.createElement('feDropShadow');
             shadowDom.appendChild(domChild);
             this.addDom(shadowDom);
         }
@@ -98,11 +99,12 @@ export default class ShadowManager extends Definable {
         let offsetX = style.shadowOffsetX || 0;
         let offsetY = style.shadowOffsetY || 0;
         let blur = style.shadowBlur;
-        let color = style.shadowColor;
+        const normalizedColor = normalizeColor(style.shadowColor);
 
         domChild.setAttribute('dx', offsetX / scaleX + '');
         domChild.setAttribute('dy', offsetY / scaleY + '');
-        domChild.setAttribute('flood-color', color);
+        domChild.setAttribute('flood-color', normalizedColor.color);
+        domChild.setAttribute('flood-opacity', normalizedColor.opacity + '');
 
         // Divide by two here so that it looks the same as in canvas
         // See: https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-shadowblur
@@ -134,9 +136,11 @@ export default class ShadowManager extends Definable {
         let shadowDomsPool = this._shadowDomPool;
 
         // let currentUsedShadow = 0;
-        for (let key in this._shadowDomMap) {
-            const dom = this._shadowDomMap[key];
-            shadowDomsPool.push(dom);
+        const shadowDomMap = this._shadowDomMap;
+        for (let key in shadowDomMap) {
+            if (shadowDomMap.hasOwnProperty(key)) {
+                shadowDomsPool.push(shadowDomMap[key]);
+            }
             // currentUsedShadow++;
         }
 


### PR DESCRIPTION
1) fix apache/echarts#15023, rect path can't be closed.
2) fix apache/echarts#15029 normalize color when using SVG renderer to support more cases, for example, some tools/platforms can't recognize the alpha in color. See the screenshot below.
3) fix eslint error about `for-in`.

PPT

<img src="https://user-images.githubusercontent.com/26999792/119941384-1d895700-bfc3-11eb-9cf9-2798576c2e31.png" width="400">

### Others

There is another related issue apache/echarts#15064, I have no good and easy idea about it currently.