### PR TITLE
fix: legend text.lineHeight option not work

### DIFF
--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -810,7 +810,7 @@ class ZRText extends Displayable<TextProps> {
 
         let rectEl: Rect;
         let imgEl: ZRImage;
-        if (isPlainOrGradientBg || (textBorderWidth && textBorderColor)) {
+        if (isPlainOrGradientBg || style.lineHeight || (textBorderWidth && textBorderColor)) {
             // Background is color
             rectEl = this._getOrCreateChild(Rect);
             rectEl.useStyle(rectEl.createStyle());    // Create an empty style.
@@ -985,6 +985,7 @@ function getStyleText(style: TextStylePropsPart): string {
 function needDrawBackground(style: TextStylePropsPart): boolean {
     return !!(
         style.backgroundColor
+        || style.lineHeight
         || (style.borderWidth && style.borderColor)
     );
 }


### PR DESCRIPTION
fix the Echart's issue:
https://github.com/apache/echarts/issues/15165
https://github.com/apache/echarts/issues/15077

---
with the following config:
```javascript
        legend: {
            left: 'center',
            top: 'center',
            data:[
                'GoogleMaps','Facebook','Youtube','Google+','Weixin',
                'Twitter', 'Skype', 'Messenger', 'Whatsapp', 'Instagram'
            ],
            textStyle: {
                lineHeight: 100,
            },
        },
```

Before fixed, `legend.textStyle.lineHeight` is not working.

![image](https://user-images.githubusercontent.com/10973821/122240686-8c880a80-cef4-11eb-9a65-6078a736c8c9.png)

After fixed:

![image](https://user-images.githubusercontent.com/10973821/122240797-9f9ada80-cef4-11eb-9cd4-663903f44bf1.png)
