### PR TITLE
fix(canvas): fix unexpected `none` or `null` value for ctx.strokeStyle & ctx.fillStyle

### DIFF
--- a/src/canvas/graphic.ts
+++ b/src/canvas/graphic.ts
@@ -20,9 +20,9 @@ import { REDARAW_BIT, SHAPE_CHANGED_BIT } from '../graphic/constants';
 const pathProxyForDraw = new PathProxy(true);
 
 // Not use el#hasStroke because style may be different.
-function styleHasStroke(style: PathStyleProps) {
+function styleHasStroke(style: PathStyleProps, excludeLineWidth?: boolean) {
     const stroke = style.stroke;
-    return !(stroke == null || stroke === 'none' || !(style.lineWidth > 0));
+    return stroke != null && stroke !== 'none' && (excludeLineWidth || style.lineWidth > 0);
 }
 
 function styleHasFill(style: PathStyleProps) {
@@ -459,14 +459,14 @@ function bindPathAndTextCommonStyle(
             flushPathDrawn(ctx, scope);
             styleChanged = true;
         }
-        ctx.fillStyle = style.fill as string;
+        ctx.fillStyle = styleHasFill(style) ? style.fill : '';
     }
     if (forceSetAll || style.stroke !== prevStyle.stroke) {
         if (!styleChanged) {
             flushPathDrawn(ctx, scope);
             styleChanged = true;
         }
-        ctx.strokeStyle = style.stroke as string;
+        ctx.strokeStyle = styleHasStroke(style, true) ? style.stroke : '';
     }
     if (forceSetAll || style.opacity !== prevStyle.opacity) {
         if (!styleChanged) {

--- a/src/canvas/graphic.ts
+++ b/src/canvas/graphic.ts
@@ -20,9 +20,17 @@ import { REDARAW_BIT, SHAPE_CHANGED_BIT } from '../graphic/constants';
 const pathProxyForDraw = new PathProxy(true);
 
 // Not use el#hasStroke because style may be different.
-function styleHasStroke(style: PathStyleProps, excludeLineWidth?: boolean) {
+function styleHasStroke(style: PathStyleProps) {
     const stroke = style.stroke;
-    return stroke != null && stroke !== 'none' && (excludeLineWidth || style.lineWidth > 0);
+    return !(stroke == null || stroke === 'none' || !(style.lineWidth > 0));
+}
+
+// ignore lineWidth and must be string
+// Expected color but found '[' when color is gradient
+function isValidStrokeFillStyle(
+    strokeOrFill: PathStyleProps['stroke'] | PathStyleProps['fill']
+): strokeOrFill is string {
+    return strokeOrFill != null && strokeOrFill !== 'none' && typeof strokeOrFill === 'string';
 }
 
 function styleHasFill(style: PathStyleProps) {
@@ -459,14 +467,14 @@ function bindPathAndTextCommonStyle(
             flushPathDrawn(ctx, scope);
             styleChanged = true;
         }
-        ctx.fillStyle = styleHasFill(style) ? style.fill : '';
+        isValidStrokeFillStyle(style.fill) && (ctx.fillStyle = style.fill);
     }
     if (forceSetAll || style.stroke !== prevStyle.stroke) {
         if (!styleChanged) {
             flushPathDrawn(ctx, scope);
             styleChanged = true;
         }
-        ctx.strokeStyle = styleHasStroke(style, true) ? style.stroke : '';
+        isValidStrokeFillStyle(style.stroke) && (ctx.strokeStyle = style.stroke);
     }
     if (forceSetAll || style.opacity !== prevStyle.opacity) {
         if (!styleChanged) {


### PR DESCRIPTION
To resolve apache/echarts#15238.

Because unexpected value `null` or `'none'` is assigned to `ctx.strokeStyle` or `ctx.fillStyle`, the Firefox devtools will print lots of annoying CSS warnings.