### PR TITLE
fix(text): fix a typo. `getStroke` should be `getFill`.

### DIFF
--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -745,7 +745,7 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
         const defaultStyle = this._defaultStyle;
         let useDefaultFill = false;
         let defaultLineWidth = 0;
-        const textFill = getStroke(
+        const textFill = getFill(
             'fill' in tokenStyle ? tokenStyle.fill
                 : 'fill' in style ? style.fill
                 : (useDefaultFill = true, defaultStyle.fill)


### PR DESCRIPTION
https://github.com/ecomfe/zrender/blob/master/src/graphic/Text.ts#L748-L752