### PR TITLE
fix several render bugs.

### DIFF
--- a/src/svg/core.ts
+++ b/src/svg/core.ts
@@ -9,7 +9,7 @@ export function normalizeColor(color: string): { color: string, opacity: number 
     if (!color || color === 'transparent') {
         color = 'none';
     }
-    else if (color.indexOf('rgba') > -1) {
+    else if (typeof color === 'string' && color.indexOf('rgba') > -1) {
         const arr = parse(color);
         if (arr) {
             color = 'rgb(' + arr[0] + ',' + arr[1] + ',' + arr[2] + ')';


### PR DESCRIPTION
1. Fix small line segment is drawn wrong when with other path primitives like `bezierCurve` brought in #760 . The pending line segment should be drawn before drawing other types of primitives. Fix https://github.com/apache/echarts/issues/15380
2. Fix normalizeColor throw error when using a gradient as color in SVG brought in #767