### PR TITLE
fix(helper): add fallback to avoid undefined TypeError

### DIFF
--- a/src/graphic/helper/parseText.ts
+++ b/src/graphic/helper/parseText.ts
@@ -533,6 +533,11 @@ function pushTokens(
         strLines = str.split('\n');
     }
 
+    // fallback in case of undefined exception
+    if (strLines === undefined) {
+        strLines = str.split('\n')
+    }
+
     for (let i = 0; i < strLines.length; i++) {
         const text = strLines[i];
         const token = new RichTextToken();


### PR DESCRIPTION
In some cases, `strLines` can be `undefined` along some code path
in `pushTokens`, resulting in undefined TypeError.

This PR is verified to fix the issue.