### PR TITLE
fix(matrix): union return type for function invert

### DIFF
--- a/src/core/matrix.ts
+++ b/src/core/matrix.ts
@@ -116,7 +116,7 @@ export function scale(out: MatrixArray, a: MatrixArray, v: VectorArray): MatrixA
 /**
  * 求逆矩阵
  */
-export function invert(out: MatrixArray, a: MatrixArray): MatrixArray {
+export function invert(out: MatrixArray, a: MatrixArray): MatrixArray | null {
 
     const aa = a[0];
     const ac = a[2];


### PR DESCRIPTION
tsc complains about the return type of function invert with **strictNullChecks** enabled.

![image](https://user-images.githubusercontent.com/33564834/130031921-8a87d7d1-cbad-4781-9778-a6e786b38498.png)

The return type is altered to a union type.

Typescript version: 4.3.4