### PR TITLE
fix(svg): SVG <image> tag also should consider `href` attribute.

### DIFF
--- a/src/tool/parseSVG.ts
+++ b/src/tool/parseSVG.ts
@@ -479,7 +479,7 @@ class SVGParser {
                 parseAttributes(xmlNode, img, this._defsUsePending, false, false);
 
                 img.setStyle({
-                    image: xmlNode.getAttribute('xlink:href'),
+                    image: xmlNode.getAttribute('xlink:href') || xmlNode.getAttribute('href'),
                     x: +xmlNode.getAttribute('x'),
                     y: +xmlNode.getAttribute('y'),
                     width: +xmlNode.getAttribute('width'),


### PR DESCRIPTION
Resolves apache/echarts#15597

The [`image`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/image) element in SVG support both `xlink:href` attribute and `link` attribute. [`xlink:href`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href) seems not recommended anymore. But at least, we should consider supporting the `link` attribute.

<img src="https://user-images.githubusercontent.com/26999792/130713464-571c6813-94b2-466a-a4ff-bfdc4dc5ca40.png" width="400">

