### PR TITLE
fix(svg): fix illegal value for `stroke-dasharray` attribute.

### DIFF
--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -87,7 +87,7 @@ function bindStyle(svgEl: SVGElement, style: AllStyleOption, el?: Path | TSpan |
 
     // only set opacity. stroke and fill cannot be applied to svg image
     if (el instanceof ZRImage) {
-        svgEl.style.opacity = opacity + '';
+        attr(svgEl, 'opacity', opacity + '');
         return;
     }
 
@@ -137,7 +137,7 @@ function bindStyle(svgEl: SVGElement, style: AllStyleOption, el?: Path | TSpan |
             attr(svgEl, 'stroke-dashoffset', (lineDashOffset || 0) + '');
         }
         else {
-            attr(svgEl, 'stroke-dasharray', '');
+            attr(svgEl, 'stroke-dasharray', NONE);
         }
 
         // PENDING


### PR DESCRIPTION
Fix illegal value for the `stroke-dasharray` attribute.

<img src="https://user-images.githubusercontent.com/26999792/131629379-3a13d9aa-e252-44fc-9297-1b002b03aed6.png" height="30">


Additionally, use the `opacity` attribute instead of CSS style property to enhance the compatibility.