### PR TITLE
fix(svg): svg mouse event doesn't work normally in Firefox when using shadow.

### DIFF
--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -67,6 +67,8 @@ export function clientToLocal(
     // <https://bugs.jquery.com/ticket/8523#comment:14>
     // BTW3, In ff, offsetX/offsetY is always 0.
     else if (env.browser.firefox
+        // use offsetX/offsetY for Firefox >= 39
+        // PENDING: consider Firefox for Android and Firefox OS? >= 43
         && env.browser.version < '39'
         && (e as FirefoxMouseEvent).layerX != null
         && (e as FirefoxMouseEvent).layerX !== (e as MouseEvent).offsetX
@@ -74,7 +76,7 @@ export function clientToLocal(
         out.zrX = (e as FirefoxMouseEvent).layerX;
         out.zrY = (e as FirefoxMouseEvent).layerY;
     }
-    // For IE6+, chrome, safari, opera. (When will ff support offsetX?)
+    // For IE6+, chrome, safari, opera, firefox >= 39
     else if ((e as MouseEvent).offsetX != null) {
         out.zrX = (e as MouseEvent).offsetX;
         out.zrY = (e as MouseEvent).offsetY;

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -67,6 +67,7 @@ export function clientToLocal(
     // <https://bugs.jquery.com/ticket/8523#comment:14>
     // BTW3, In ff, offsetX/offsetY is always 0.
     else if (env.browser.firefox
+        && env.browser.version < '39'
         && (e as FirefoxMouseEvent).layerX != null
         && (e as FirefoxMouseEvent).layerX !== (e as MouseEvent).offsetX
     ) {

--- a/src/svg/helper/ShadowManager.ts
+++ b/src/svg/helper/ShadowManager.ts
@@ -73,7 +73,7 @@ export default class ShadowManager extends Definable {
     remove(svgElement: SVGElement, displayable: Displayable) {
         if ((displayable as DisplayableExtended)._shadowDom != null) {
             (displayable as DisplayableExtended)._shadowDom = null;
-            svgElement.style.filter = '';
+            svgElement.removeAttribute('filter');
         }
     }
 
@@ -124,7 +124,7 @@ export default class ShadowManager extends Definable {
         (displayable as DisplayableExtended)._shadowDom = shadowDom;
 
         const id = shadowDom.getAttribute('id');
-        svgElement.style.filter = 'url(#' + id + ')';
+        svgElement.setAttribute('filter', 'url(#' + id + ')');
     }
 
     removeUnused() {


### PR DESCRIPTION
Fix apache/echarts#15646
Fix apache/echarts#15697

It seems the `layerX/layerY` is unexpected in the case where the chart uses SVG renderer and has shadow filter.

<img src="https://user-images.githubusercontent.com/26999792/131673011-39a37814-f253-4964-a6b5-843bdef5cbe2.png" width="400">

From the above picture, we can see that the values of `layerX/layerY`(unexpected) are not the same as `offsetX/offsetY`(expected) and don't look like the offset relative to the "closest positioned element". (I couldn't know the reason)

According to [CANIUSE](https://caniuse.com/?search=offsetX) and the [release note](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/39) of Firefox, the `offsetX` and `offsetY` have been supported since desktop Firefox 39 

> Support for MouseEvent.offsetX and MouseEvent.offsetY have been added on desktop (bug 69787, but not on Firefox for Android or Firefox OS (they will be added in Firefox 43).

And they have been also supported by Firefox for Android and Firefox OS since [v43](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/43)

> Support for MouseEvent.offsetX and MouseEvent.offsetY have been activated on Firefox for Android and Firefox OS (bug 1204841).

As mentioned above, I'd like to use `offsetX/offsetY` for modern Firefox.

A reproducible demo:

```js
// Please use SVG renderer
option = {
  title: {
    text: '某站点用户访问来源',
    subtext: '纯属虚构',
    left: 'center'
  },
  tooltip: {
    trigger: 'item'
  },
  legend: {
    orient: 'vertical',
    left: 'left',
  },
  series: [
    {
      name: '访问来源',
      type: 'pie',
      radius: '50%',
      data: [
        {value: 1048, name: '搜索引擎'},
        {value: 735, name: '直接访问'},
        {value: 580, name: '邮件营销'},
        {value: 484, name: '联盟广告'},
        {value: 300, name: '视频广告'}
      ],
      emphasis: {
        itemStyle: {
          shadowBlur: 10,
          shadowOffsetX: 0,
          shadowColor: 'red'
        }
      }
    }
  ]
};
```

In addition, if we change to use `offsetX/offsetY`, it will make the feature mentiond in #794 possible.


 