### PR TITLE
fix: export Displayable for type annotation compatibility

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -23,6 +23,7 @@ export {
     ElementProps
 } from './Element';
 
+export {default as Displayable, DisplayableProps} from './graphic/Displayable';
 export {default as Group, GroupProps} from './graphic/Group';
 export {default as Path, PathStyleProps, PathProps, PathStatePropNames, PathState} from './graphic/Path';
 export {default as Image, ImageStyleProps, ImageProps, ImageState} from './graphic/Image';


### PR DESCRIPTION
Export Displayable so it can be used for type annotation, especially in the case below
```ts
import * as zrender from 'zrender'

function (g: zrender.Group) {
    g.eachChild((el: zrender.Displayable) => { /* do something */ })
}
```