### PR TITLE
fix: always close path on circle

### DIFF
--- a/src/graphic/shape/Circle.ts
+++ b/src/graphic/shape/Circle.ts
@@ -25,20 +25,9 @@ class Circle extends Path<CircleProps> {
         return new CircleShape();
     }
 
-    buildPath(ctx: CanvasRenderingContext2D, shape: CircleShape, inBundle: boolean) {
-        // Better stroking in ShapeBundle
-        // Always do it may have performence issue ( fill may be 2x more cost)
-        if (inBundle) {
-            ctx.moveTo(shape.cx + shape.r, shape.cy);
-        }
-        // else {
-        //     if (ctx.allocate && !ctx.data.length) {
-        //         ctx.allocate(ctx.CMD_MEM_SIZE.A);
-        //     }
-        // }
-        // Better stroking in ShapeBundle
-        // ctx.moveTo(shape.cx + shape.r, shape.cy);
+    buildPath(ctx: CanvasRenderingContext2D, shape: CircleShape) {
         ctx.arc(shape.cx, shape.cy, shape.r, 0, Math.PI * 2);
+        ctx.closePath();
     }
 };
 


### PR DESCRIPTION
The original logic is too tricky and may still break when autoBatch is enabled. So in this PR I changed to always close the path.

Before
![image](https://user-images.githubusercontent.com/841551/133882011-e52c54d0-e1be-49d5-a823-bfd6fa3214c1.png)

After
![image](https://user-images.githubusercontent.com/841551/133882034-f729fe9e-c76b-4073-99c3-994923a5ea03.png)

