### PR TITLE
fix: optimize arraydiff perf in first render and clear

### DIFF
--- a/src/core/arrayDiff.ts
+++ b/src/core/arrayDiff.ts
@@ -14,6 +14,8 @@ type DiffPath = {
     newPos: number
 }
 
+// Using O(ND) algorithm
+// TODO: Optimize when diff is large.
 function diff<T>(oldArr: T[], newArr: T[], equals: EqualFunc<T>): DiffComponent[] {
     if (!equals) {
         equals = function (a, b) {
@@ -32,17 +34,21 @@ function diff<T>(oldArr: T[], newArr: T[], equals: EqualFunc<T>): DiffComponent[
 
     // Seed editLength = 0, i.e. the content starts with the same values
     var oldPos = extractCommon<T>(bestPath[0], newArr, oldArr, 0, equals);
-    if (bestPath[0].newPos + 1 >= newLen && oldPos + 1 >= oldLen) {
+    if (!oldLen // All new created
+        || !newLen // Clear
+        || (bestPath[0].newPos + 1 >= newLen && oldPos + 1 >= oldLen)) {
         var indices = [];
-        for (let i = 0; i < newArr.length; i++) {
+        var allCleared = !newLen && oldLen > 0;
+        var allCreated = !oldLen && newLen > 0;
+        for (let i = 0; i < (allCleared ? oldArr : newArr).length; i++) {
             indices.push(i);
         }
         // Identity per the equality and tokenizer
         return [{
             indices: indices,
-            count: newArr.length,
-            added: false,
-            removed: false
+            count: indices.length,
+            added: allCreated,
+            removed: allCleared
         }];
     }
 


### PR DESCRIPTION
Currently, we are using an O(ND) diff algorithm(Myers' Diff Algorithm) in the SVG renderer. But when we do first render or clear all things on canvas. The complex becomes O(N2) because the difference is the whole N. Which will cause a significant performance drop. Especially we can't avoid the first render. So in this PR, I did a simple optimization to handle these two cases. The time of the first frame render comes down to 100ms from the terrible 3000ms for 10k objects.

Also, I found an existing bug that appears after the change in https://github.com/ecomfe/zrender/pull/829 and fixed it.