### PR TITLE
chore: fix patch version of next build

### DIFF
--- a/build/prepareNightly.js
+++ b/build/prepareNightly.js
@@ -18,6 +18,7 @@ function updateVersion(version) {
         if (isNext) {
             // Increase minor version for next branch.
             minor++;
+            patch = 0;
         }
         else {
             // Increase main version for master branch.


### PR DESCRIPTION
The version of nightly build for next branch should be always 5.x.0