### PR TITLE
fix(bar-race): extra prop for label value animation

### DIFF
--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -189,6 +189,10 @@ export interface TextStyleProps extends TextStylePropsPart {
 
 export interface TextProps extends DisplayableProps {
     style?: TextStyleProps
+    /**
+     * For the value interpolation animation
+     */
+    value?: number | string | (number | string)[]
 
     zlevel?: number
     z?: number


### PR DESCRIPTION
Add `value` property in the `TextProps` for ECharts bar-race animation.