### PR TITLE
Expanded UNICODE range for Latin characters  from 33-255 to 33-383 

### DIFF
--- a/src/graphic/helper/parseText.ts
+++ b/src/graphic/helper/parseText.ts
@@ -578,7 +578,7 @@ function pushTokens(
 
 function isLatin(ch: string) {
     let code = ch.charCodeAt(0);
-    return code >= 0x21 && code <= 0xFF;
+    return code >= 0x21 && code <= 0x17F;
 }
 
 const breakCharMap = reduce(',&?/;] '.split(''), function (obj, ch) {


### PR DESCRIPTION
Hi, I'm doing a small project and noticed that in TextStyleProps we have `overflow?: 'break' | 'breakAll' | 'truncate' | 'none'`. The 'break' should break by word and it is, but not in all cases. 

There is a list of unicode characters divided into blocks (https://en.wikipedia.org/wiki/List_of_Unicode_characters) and zrender only considers Latin characters in the range from 33 to 255 which is 1st and 2nd block. Many European characters are in the 3rd block (Latin Extended-A https://en.wikipedia.org/wiki/Latin_Extended-A). 

Adding the 3rd UNICODE block should not cause any trouble (there are no characters that can be considered 'special') and would help a lot in using European languages because now some words are breaking in half :(
