### PR TITLE
fix(svg): update `_svgDom` when vnode changed.

### DIFF
--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -108,6 +108,7 @@ class SVGPainter implements PainterBase {
             vnode.attrs.style = 'user-select:none;position:absolute;left:0;top:0;';
             patch(this._oldVNode || this._svgDom, vnode);
             this._oldVNode = vnode;
+            this._svgDom = vnode.elm as SVGElement;
         }
     }
 

--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -9,16 +9,15 @@ import Displayable from '../graphic/Displayable';
 import Storage from '../Storage';
 import { PainterBase } from '../PainterBase';
 import {
+    createElement,
     createVNode,
     vNodeToString,
     SVGVNodeAttrs,
     SVGVNode,
-    createElement,
-    SVGNS,
-    XLINKNS,
     getCssString,
     BrushScope,
-    createBrushScope
+    createBrushScope,
+    createSVGVNode
 } from './core';
 import { normalizeColor } from './helper';
 import { defaults, extend, keys, logError, map } from '../core/util';
@@ -66,13 +65,14 @@ class SVGPainter implements PainterBase {
         // A unique id for generating svg ids.
         this._id = 'zr' + svgId++;
 
+        this._oldVNode = createSVGVNode(opts.width, opts.height);
 
         if (root && !opts.ssr) {
             const viewport = this._viewport = document.createElement('div');
-            viewport.style.cssText = 'overflow:hidden;position:relative';
-            const svgDom = this._svgDom = createElement('svg');
-            root.appendChild(viewport);
+            viewport.style.cssText = 'position:relative;overflow:hidden';
+            const svgDom = this._svgDom = this._oldVNode.elm = createElement('svg');
             viewport.appendChild(svgDom);
+            root.appendChild(viewport);
         }
 
         this.resize(opts.width, opts.height);
@@ -105,10 +105,9 @@ class SVGPainter implements PainterBase {
                 willUpdate: true
             });
             // Disable user selection.
-            vnode.attrs.style = 'user-select:none;position:absolute;left:0;top:0;';
-            patch(this._oldVNode || this._svgDom, vnode);
+            vnode.attrs.style = 'position:absolute;left:0;top:0;user-select:none';
+            patch(this._oldVNode, vnode);
             this._oldVNode = vnode;
-            this._svgDom = vnode.elm as SVGElement;
         }
     }
 
@@ -126,8 +125,8 @@ class SVGPainter implements PainterBase {
 
         const list = this.storage.getDisplayList(true);
         const bgColor = this._backgroundColor;
-        const width = this._width + '';
-        const height = this._height + '';
+        const width = this._width;
+        const height = this._height;
 
         const scope = createBrushScope(this._id);
         scope.animation = opts.animation;
@@ -176,19 +175,7 @@ class SVGPainter implements PainterBase {
             }
         }
 
-        return createVNode(
-            'svg',
-            'root',
-            {
-                'width': width,
-                'height': height,
-                'xmlns': SVGNS,
-                'xmlns:xlink': XLINKNS,
-                'version': '1.1',
-                'baseProfile': 'full'
-            },
-            children
-        );
+        return createSVGVNode(width, height, children);
     }
 
     renderToString(opts?: {

--- a/src/svg/core.ts
+++ b/src/svg/core.ts
@@ -6,6 +6,7 @@ export type CSSAnimationVNode = Record<string, Record<string, string>>
 export const SVGNS = 'http://www.w3.org/2000/svg';
 export const XLINKNS = 'http://www.w3.org/1999/xlink';
 export const XMLNS = 'http://www.w3.org/2000/xmlns/';
+export const XML_NAMESPACE = 'http://www.w3.org/XML/1998/namespace';
 
 export function createElement(name: string) {
     return document.createElementNS(SVGNS, name);

--- a/src/svg/core.ts
+++ b/src/svg/core.ts
@@ -172,3 +172,19 @@ export function createBrushScope(zrId: string): BrushScope {
         clipPathIdx: 0
     };
 }
+
+export function createSVGVNode(width?: number | string, height?: number | string, children?: SVGVNode[]) {
+    return createVNode(
+        'svg',
+        'root',
+        {
+            'width': width,
+            'height': height,
+            'xmlns': SVGNS,
+            'xmlns:xlink': XLINKNS,
+            'version': '1.1',
+            'baseProfile': 'full'
+        },
+        children
+    );
+}

--- a/src/svg/patch.ts
+++ b/src/svg/patch.ts
@@ -9,11 +9,9 @@
  */
 
 import { isArray, isObject } from '../core/util';
-import { createElement, createVNode, SVGVNode } from './core';
+import { createElement, createVNode, SVGVNode, XMLNS, XML_NAMESPACE, XLINKNS } from './core';
 import * as api from './domapi';
 
-const xlinkNS = 'http://www.w3.org/1999/xlink';
-const xmlNS = 'http://www.w3.org/XML/1998/namespace';
 const colonChar = 58;
 const xChar = 120;
 const emptyNode = createVNode('', '') as SVGVNode;
@@ -169,15 +167,15 @@ function updateAttrs(oldVnode: SVGVNode, vnode: SVGVNode): void {
                 }
                 // TODO
                 else if (key === 'xmlns:xlink' || key === 'xmlns') {
-                    elm.setAttributeNS('http://www.w3.org/2000/xmlns/', key, cur as any);
+                    elm.setAttributeNS(XMLNS, key, cur as any);
                 }
                 else if (key.charCodeAt(3) === colonChar) {
                     // Assume xml namespace
-                    elm.setAttributeNS(xmlNS, key, cur as any);
+                    elm.setAttributeNS(XML_NAMESPACE, key, cur as any);
                 }
                 else if (key.charCodeAt(5) === colonChar) {
                     // Assume xlink namespace
-                    elm.setAttributeNS(xlinkNS, key, cur as any);
+                    elm.setAttributeNS(XLINKNS, key, cur as any);
                 }
                 else {
                     elm.setAttribute(key, cur as any);

--- a/src/svg/patch.ts
+++ b/src/svg/patch.ts
@@ -41,7 +41,7 @@ function createKeyToOldIdx(
                     console.error(`Duplicate key ${key}`);
                 }
             }
-            map[key as string] = i;
+            map[key] = i;
         }
     }
     return map;
@@ -54,24 +54,7 @@ function sameVnode(vnode1: SVGVNode, vnode2: SVGVNode): boolean {
     return isSameTag && isSameKey;
 }
 
-function isVnode(vnode: any): vnode is SVGVNode {
-    return vnode.tag !== undefined;
-}
-
 type KeyToIndexMap = { [key: string]: number };
-
-function emptyNodeAt(elm: Element): SVGVNode {
-    const id = elm.id ? '#' + elm.id : '';
-
-    // elm.className doesn't return a string when elm is an SVG element inside a shadowRoot.
-    // https://stackoverflow.com/questions/29454340/detecting-classname-of-svganimatedstring
-    const classes = elm.getAttribute('class');
-
-    const c = classes ? '.' + classes.split(' ').join('.') : '';
-    const vnode = createVNode(api.tagName(elm).toLowerCase() + id + c, '') as SVGVNode;
-    vnode.elm = elm;
-    return vnode;
-}
 
 function createElm(vnode: SVGVNode, insertedVnodeQueue: VNodeQueue): Node {
     let i: any;
@@ -93,7 +76,7 @@ function createElm(vnode: SVGVNode, insertedVnodeQueue: VNodeQueue): Node {
             for (i = 0; i < children.length; ++i) {
                 const ch = children[i];
                 if (ch != null) {
-                    api.appendChild(elm, createElm(ch as SVGVNode, insertedVnodeQueue));
+                    api.appendChild(elm, createElm(ch, insertedVnodeQueue));
                 }
             }
         }
@@ -128,7 +111,7 @@ function removeVnodes(parentElm: Node, vnodes: SVGVNode[], startIdx: number, end
         const ch = vnodes[startIdx];
         if (ch != null) {
             if (isDef(ch.tag)) {
-                const parent = api.parentNode(ch.elm) as Node;
+                const parent = api.parentNode(ch.elm);
                 api.removeChild(parent, ch.elm);
             }
             else {
@@ -141,9 +124,9 @@ function removeVnodes(parentElm: Node, vnodes: SVGVNode[], startIdx: number, end
 
 function updateAttrs(oldVnode: SVGVNode, vnode: SVGVNode): void {
     let key: string;
-    const elm: Element = vnode.elm as Element;
-    let oldAttrs = oldVnode.attrs || {};
-    let attrs = vnode.attrs || {};
+    const elm = vnode.elm as Element;
+    const oldAttrs = oldVnode.attrs || {};
+    const attrs = vnode.attrs || {};
 
     if (oldAttrs === attrs) {
         return;
@@ -284,8 +267,8 @@ function updateChildren(
 
 function patchVnode(oldVnode: SVGVNode, vnode: SVGVNode, insertedVnodeQueue: VNodeQueue) {
     const elm = (vnode.elm = oldVnode.elm)!;
-    const oldCh = oldVnode.children as SVGVNode[];
-    const ch = vnode.children as SVGVNode[];
+    const oldCh = oldVnode.children;
+    const ch = vnode.children;
     if (oldVnode === vnode) {
         return;
     }
@@ -319,21 +302,15 @@ function patchVnode(oldVnode: SVGVNode, vnode: SVGVNode, insertedVnodeQueue: VNo
     }
 }
 
-export default function patch(oldVnode: SVGVNode | Element, vnode: SVGVNode): SVGVNode {
-    let elm: Node;
-    let parent: Node;
+export default function patch(oldVnode: SVGVNode, vnode: SVGVNode): SVGVNode {
     const insertedVnodeQueue: VNodeQueue = [];
-
-    if (!isVnode(oldVnode)) {
-        oldVnode = emptyNodeAt(oldVnode);
-    }
 
     if (sameVnode(oldVnode, vnode)) {
         patchVnode(oldVnode, vnode, insertedVnodeQueue);
     }
     else {
-        elm = oldVnode.elm!;
-        parent = api.parentNode(elm) as Node;
+        const elm = oldVnode.elm!;
+        const parent = api.parentNode(elm);
 
         createElm(vnode, insertedVnodeQueue);
 


### PR DESCRIPTION
The initial [`_svgDom`](https://github.com/ecomfe/zrender/blob/next/src/svg/Painter.ts#L73) will be removed and replaced by the newly generated element after the [patch](https://github.com/ecomfe/zrender/blob/next/src/svg/patch.ts#L344) process so that all next operations on the old `_svgDom` won't work, e.g. `resize`, `innerHTML`, `clear`.