### PR TITLE
fix(svg): set attributes for svg dom when initializing.

### DIFF
--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -22,7 +22,7 @@ import {
 import { normalizeColor } from './helper';
 import { defaults, extend, keys, logError, map } from '../core/util';
 import Path from '../graphic/Path';
-import patch from './patch';
+import patch, { updateAttrs } from './patch';
 import { getSize } from '../canvas/helper';
 
 let svgId = 0;
@@ -71,6 +71,7 @@ class SVGPainter implements PainterBase {
             const viewport = this._viewport = document.createElement('div');
             viewport.style.cssText = 'position:relative;overflow:hidden';
             const svgDom = this._svgDom = this._oldVNode.elm = createElement('svg');
+            updateAttrs(null, this._oldVNode);
             viewport.appendChild(svgDom);
             root.appendChild(viewport);
         }

--- a/src/svg/patch.ts
+++ b/src/svg/patch.ts
@@ -120,10 +120,10 @@ function removeVnodes(parentElm: Node, vnodes: SVGVNode[], startIdx: number, end
     }
 }
 
-function updateAttrs(oldVnode: SVGVNode, vnode: SVGVNode): void {
+export function updateAttrs(oldVnode: SVGVNode, vnode: SVGVNode): void {
     let key: string;
     const elm = vnode.elm as Element;
-    const oldAttrs = oldVnode.attrs || {};
+    const oldAttrs = oldVnode && oldVnode.attrs || {};
     const attrs = vnode.attrs || {};
 
     if (oldAttrs === attrs) {


### PR DESCRIPTION
Fix a bug brought in #853. After the patch, No XML NS attributes were set on the `svg` DOM because of the same attributes in vnode.

<img src="https://user-images.githubusercontent.com/26999792/144539980-ad23197f-9b86-4d30-9b31-17c72edb5b46.png" width="400">

So here we set attributes for `svg` dom when initializing.

<img src="https://user-images.githubusercontent.com/26999792/144540300-ff3be520-6288-48d2-9f5c-e9bb8a837d17.png" width="400">

