### PR TITLE
fix(animation): ignore loop animation when switching state.

### DIFF
--- a/src/Element.ts
+++ b/src/Element.ts
@@ -752,7 +752,8 @@ class Element<Props extends ElementProps = ElementProps> {
             const animator = this.animators[i];
             const fromStateTransition = animator.__fromStateTransition;
             // Ignore animation from state transition(except normal).
-            if (fromStateTransition && fromStateTransition !== PRESERVED_NORMAL_STATE) {
+            // Ignore loop animation.
+            if (animator.getLoop() || fromStateTransition && fromStateTransition !== PRESERVED_NORMAL_STATE) {
                 continue;
             }
 
@@ -1161,10 +1162,13 @@ class Element<Props extends ElementProps = ElementProps> {
             for (let i = 0; i < this.animators.length; i++) {
                 const animator = this.animators[i];
                 const targetName = animator.targetName;
-                animator.__changeFinalValue(targetName
-                    ? ((state || normalState) as any)[targetName]
-                    : (state || normalState)
-                );
+                // Ignore loop animation
+                if (!animator.getLoop()) {
+                    animator.__changeFinalValue(targetName
+                        ? ((state || normalState) as any)[targetName]
+                        : (state || normalState)
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
As @plainheart pointed out in https://github.com/apache/echarts/pull/16225#issuecomment-998492571 . The looped keyframe animation may have conflict with the state transition animation. Because in the logic of handling state transition, the final frame of other animators will also be considered. But it's meaningless in a looped animation because it doesn't have final frame.

This PR fixes it by ignoring the loop animators. It's not perfect, we still have more things to do to deal with the keyframe animation combined with state transition. For example, how should the animation performs when keyframe animation and state transition both animated on the opacity. But this fix is simple and do well enough on most cases. So I proposed it before we rethinking the relationships of different animations and do more complex refactors.