### PR TITLE
fix(svg): fix animation on strokePercent will cause partially drawing.

### DIFF
--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -133,6 +133,7 @@ const buitinShapesDef: Record<string, [ConvertShapeToAttr, ShapeValidator?]> = {
 interface PathWithSVGBuildPath extends Path {
     __svgPathVersion: number
     __svgPathBuilder: SVGPathRebuilder
+    __svgPathStrokePercent: number
 }
 
 function hasShapeAnimation(el: Displayable) {
@@ -185,7 +186,7 @@ export function brushSVGPath(el: Path, scope: BrushScope) {
         let svgPathBuilder = elExt.__svgPathBuilder;
         if (elExt.__svgPathVersion !== pathVersion
             || !svgPathBuilder
-            || strokePercent < 1
+            || el.style.strokePercent !== elExt.__svgPathStrokePercent
         ) {
             if (!svgPathBuilder) {
                 svgPathBuilder = elExt.__svgPathBuilder = new SVGPathRebuilder();
@@ -194,6 +195,7 @@ export function brushSVGPath(el: Path, scope: BrushScope) {
             path.rebuildPath(svgPathBuilder, strokePercent);
             svgPathBuilder.generateStr();
             elExt.__svgPathVersion = pathVersion;
+            elExt.__svgPathStrokePercent = el.style.strokePercent;
         }
 
         attrs.d = svgPathBuilder.getStr();

--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -186,7 +186,7 @@ export function brushSVGPath(el: Path, scope: BrushScope) {
         let svgPathBuilder = elExt.__svgPathBuilder;
         if (elExt.__svgPathVersion !== pathVersion
             || !svgPathBuilder
-            || el.style.strokePercent !== elExt.__svgPathStrokePercent
+            || strokePercent !== elExt.__svgPathStrokePercent
         ) {
             if (!svgPathBuilder) {
                 svgPathBuilder = elExt.__svgPathBuilder = new SVGPathRebuilder();
@@ -195,7 +195,7 @@ export function brushSVGPath(el: Path, scope: BrushScope) {
             path.rebuildPath(svgPathBuilder, strokePercent);
             svgPathBuilder.generateStr();
             elExt.__svgPathVersion = pathVersion;
-            elExt.__svgPathStrokePercent = el.style.strokePercent;
+            elExt.__svgPathStrokePercent = strokePercent;
         }
 
         attrs.d = svgPathBuilder.getStr();


### PR DESCRIPTION
If we apply an animation on 'style.strokePercent' from 0 to 1, the shape won't be drawn completely using SVG renderer.

![image](https://user-images.githubusercontent.com/15250494/147801498-7a4fe124-02c4-4250-bf29-524a37e0bd01.png)

This problem can be reproduced. You can reference https://codesandbox.io/s/condescending-mclaren-qrhdx?file=/src/App.js . If you click 'Restart Stroke Percent Animation' a few times, you'll see different results.