### PR TITLE
fix(animator): `NaN` shouldn't be considered as the number type.

### DIFF
--- a/src/animation/Animator.ts
+++ b/src/animation/Animator.ts
@@ -4,7 +4,7 @@
 
 import Clip from './Clip';
 import * as color from '../tool/color';
-import {extend, isArrayLike, isFunction, isGradientObject, isNumber, isString, keys, logError, map} from '../core/util';
+import {eqNaN, extend, isArrayLike, isFunction, isGradientObject, isNumber, isString, keys, logError, map} from '../core/util';
 import {ArrayLike, Dictionary} from '../core/types';
 import easingFuncs, { AnimationEasing } from './easing';
 import Animation from './Animation';
@@ -306,7 +306,7 @@ class Track {
             }
         }
         else {
-            if (isNumber(value)) {
+            if (isNumber(rawValue) && !eqNaN(rawValue)) {
                 valType = VALUE_TYPE_NUMBER;
             }
             else if (isString(rawValue)) {


### PR DESCRIPTION
Currently `NaN` is being unexpectedly considered as the number type. It brings some bugs to animation.

Fix apache/echarts#16341

Please refer to the last test case in [`test/pie-animation.html`](https://github.com/apache/echarts/blob/next/test/pie-animation.html)

|  Before   | After  |
|  :----:  | :----:  |
| ![bug](https://user-images.githubusercontent.com/26999792/148653471-ab5faf47-659c-43f7-9703-502d284b42f8.gif) | ![right](https://user-images.githubusercontent.com/26999792/148653482-c32162bb-b896-4c17-b948-602b73a0d40d.gif) |
