### PR TITLE
fix potential NPE in `toDataURL` function in the legacy SVG renderer. remove unused import.

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -1,5 +1,4 @@
 import * as util from './core/util';
-import env from './core/env';
 import Group, { GroupLike } from './graphic/Group';
 import Element from './Element';
 

--- a/src/svg-legacy/Painter.ts
+++ b/src/svg-legacy/Painter.ts
@@ -399,7 +399,7 @@ class SVGPainter implements PainterBase {
         const outerHTML = svgDom.outerHTML
             // outerHTML of `svg` tag is not supported in IE, use `parentNode.innerHTML` instead
             // PENDING: Or use `new XMLSerializer().serializeToString(svg)`?
-            || (svgDom.parentNode && svgDom.parentNode as HTMLElement).innerHTML;
+            || (svgDom.parentNode && (svgDom.parentNode as HTMLElement).innerHTML);
         const html = encodeURIComponent(outerHTML.replace(/></g, '>\n\r<'));
         return 'data:image/svg+xml;charset=UTF-8,' + html;
     }


### PR DESCRIPTION
Fixed two issues raised by [DeepScan](https://deepscan.io/dashboard/#view=project&tid=16023&pid=19250&bid=524130&subview=pull-request&prid=1074174).