### PR TITLE
fix(sector): fix a case in which the angle is NaN.

### DIFF
--- a/src/graphic/helper/roundSector.ts
+++ b/src/graphic/helper/roundSector.ts
@@ -145,11 +145,13 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
         innerRadius = tmp;
     }
 
+    const { startAngle, endAngle } = shape;
+    if (isNaN(startAngle) || isNaN(endAngle)) {
+        return;
+    }
+
+    const { cx, cy } = shape;
     const clockwise = !!shape.clockwise;
-    const { cx, cy, cornerRadius } = shape;
-    // may be NaN
-    const startAngle = shape.startAngle || 0;
-    const endAngle = shape.endAngle || 0;
 
     let arc = mathAbs(endAngle - startAngle);
     const mod = arc > PI2 && arc % PI2;
@@ -204,6 +206,7 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
 
         const hasArc = arc > e;
         if (hasArc) {
+            const cornerRadius = shape.cornerRadius;
             if (cornerRadius) {
                 [icrStart, icrEnd, ocrStart, ocrEnd] = normalizeCornerRadius(cornerRadius);
             }

--- a/src/graphic/helper/roundSector.ts
+++ b/src/graphic/helper/roundSector.ts
@@ -146,7 +146,10 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
     }
 
     const clockwise = !!shape.clockwise;
-    const { startAngle, endAngle, cx, cy, cornerRadius } = shape;
+    const { cx, cy, cornerRadius } = shape;
+    // may be NaN
+    const startAngle = shape.startAngle || 0;
+    const endAngle = shape.endAngle || 0;
 
     let arc = mathAbs(endAngle - startAngle);
     const mod = arc > PI2 && arc % PI2;

--- a/test/sector.html
+++ b/test/sector.html
@@ -220,6 +220,21 @@
                 // clockwise: false
             }
         }));
+
+        // should show nothing
+        zr.add(new zrender.Sector({
+            position: [400, 650],
+            scale: [1, 1],
+            style: {
+                stroke: 'black',
+                lineWidth: 10
+            },
+            shape: {
+                startAngle: NaN,
+                endAngle: NaN,
+                r: 100
+            }
+        }));
     </script>
     <div id="main" style="width:1000px;height:800px;"></div>
 </body>


### PR DESCRIPTION
In #870, we fixed the animation bug caused by the `NaN` value. But that only works in canvas renderer. In SVG renderer, the path can't be successfully built because of the `NaN` value.

The related test case is the same as #870, that is, the last test case in echarts/test/pie-animation.html