### PR TITLE
Update index.d.ts #724

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-export * from './src/zrender';
-export * from './src/export';
+export * from './lib/zrender';
+export * from './lib/export';


### PR DESCRIPTION
The type should not point to the source code, which will cause the upper layer to rely on the compilation type to report an error
#724