### PR TITLE
fix(dirtyRect):  text dirty rect considered when text in host

### DIFF
--- a/src/canvas/Layer.ts
+++ b/src/canvas/Layer.ts
@@ -269,7 +269,7 @@ export default class Layer extends Eventful {
                  * if it's currently on the canvas and needs repaint this frame
                  * or not painted this frame.
                  */
-                const shouldPaint = el.shouldBePainted(viewWidth, viewHeight, true, true);
+                const shouldPaint = el.shouldBePainted(viewWidth, viewHeight, true, true, true);
                 const prevRect = el.__isRendered && ((el.__dirty & REDRAW_BIT) || !shouldPaint)
                     ? el.getPrevPaintRect()
                     : null;
@@ -311,7 +311,7 @@ export default class Layer extends Eventful {
              * rect if and only if it's not painted this frame and was
              * previously painted on the canvas.
              */
-            const shouldPaint = el.shouldBePainted(viewWidth, viewHeight, true, true);
+            const shouldPaint = el.shouldBePainted(viewWidth, viewHeight, true, true, true);
             if (el && (!shouldPaint || !el.__zr) && el.__isRendered) {
                 // el was removed
                 const prevRect = el.getPrevPaintRect();

--- a/src/canvas/graphic.ts
+++ b/src/canvas/graphic.ts
@@ -615,7 +615,7 @@ export function brush(
 ) {
     const m = el.transform;
 
-    if (!el.shouldBePainted(scope.viewWidth, scope.viewHeight, false, false)) {
+    if (!el.shouldBePainted(scope.viewWidth, scope.viewHeight, false, false, false)) {
         // Needs to mark el rendered.
         // Or this element will always been rendered in progressive rendering.
         // But other dirty bit should not be cleared, otherwise it cause the shape

--- a/src/graphic/Displayable.ts
+++ b/src/graphic/Displayable.ts
@@ -195,7 +195,8 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
         viewWidth: number,
         viewHeight: number,
         considerClipPath: boolean,
-        considerAncestors: boolean
+        considerAncestors: boolean,
+        considerHostTarget: boolean
     ) {
         const m = this.transform;
         if (
@@ -226,6 +227,23 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
 
         if (considerAncestors && this.parent) {
             let parent = this.parent;
+            while (parent) {
+                if (parent.ignore) {
+                    return false;
+                }
+                parent = parent.parent;
+            }
+        }
+
+        // consider host target
+        if (
+            considerAncestors
+            && considerHostTarget
+            && this.parent
+            && this.parent.__hostTarget
+        ) {
+            let hostTarget = this.parent.__hostTarget;
+            let parent = hostTarget;
             while (parent) {
                 if (parent.ignore) {
                     return false;


### PR DESCRIPTION
- Resolve https://github.com/apache/echarts/issues/16534

### Why
when enabling dirty rect, and then clicking the button in the toolbox, the zrender consider where should to repainted, but does not consider text when they are hosted in another element, so, maybe we should consider ignore textElment when they hosted in other element and the host element that is ignored.

### Before 
<img width="952" alt="image" src="https://user-images.githubusercontent.com/56526981/154994002-abd619d9-e1c2-4e9a-a40a-b11a483ad224.png">

### After
<img width="1235" alt="image" src="https://user-images.githubusercontent.com/56526981/154994157-b0ed5b9e-9c4b-4b19-88cd-aeb94f26b9e0.png">

