### PR TITLE
fix: 修复createOrUpdateImage方法image实例丢失的问题

### DIFF
--- a/src/graphic/helper/image.ts
+++ b/src/graphic/helper/image.ts
@@ -65,7 +65,7 @@ export function createOrUpdateImage<T>(
             !isImageReady(image) && cachedImgObj.pending.push(pendingWrap);
         }
         else {
-            const image = platformApi.loadImage(
+            image = platformApi.loadImage(
                 newImageOrSrc, imageOnLoad, imageOnLoad
             );
             (image as any).__zrImageSrc = newImageOrSrc;


### PR DESCRIPTION
image 中 定义onload 方法取不到该图片高/宽

