### PR TITLE
fix(mouseout event): element mouseout event not working

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -240,6 +240,7 @@ class Handler extends Eventful {
             // FIXME: if the pointer moving from the extra doms to realy "outside",
             // the `globalout` should have been triggered. But currently not.
             this.trigger('globalout', {type: 'globalout', event: event});
+            this._hovered = new HoveredResult(0, 0);
         }
     }
 


### PR DESCRIPTION
## Brief Information
This pull request is in the type of:

 - [x] bug fixing
 - [ ] new feature
 - [ ] others

### What does this PR do?
Fix a bug that if the pointer moving from the extra doms to really "outside",  the value of the private variable "_hovered" needs to be set to “new HoveredResult(0, 0)”. Otherwise, the mouseout event won't fire when you move in from really outside the element for the second time.

### Fixed issues
null

## Details
codesandbox demo: https://codesandbox.io/s/zrender-bug-mouseout-685bsn

## Others
Please help to review and solve as soon as possible.