### PR TITLE
Feature: coarse pointer tolerance

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -132,6 +132,8 @@ const handlerNames = [
 type HandlerName = 'click' |'dblclick' |'mousewheel' |'mouseout' |
     'mouseup' |'mousedown' |'mousemove' |'contextmenu';
 
+const tmpRect = new BoundingRect(0, 0, 0, 0);
+
 // TODO draggable
 class Handler extends Eventful {
 
@@ -368,14 +370,17 @@ class Handler extends Eventful {
             const pointerSize = this._pointerSize;
             const targetSizeHalf = pointerSize / 2;
             const pointerRect = new BoundingRect(x - targetSizeHalf, y - targetSizeHalf, pointerSize, pointerSize);
+
             for (let i = list.length - 1; i >= 0; i--) {
                 if (list[i] !== exclude
                     && !list[i].ignore
                     && !list[i].ignoreTargetSize
                 ) {
-                    const rect = list[i].getBoundingRect().clone();
-                    rect.applyTransform(list[i].transform);
-                    if (rect.intersect(pointerRect)) {
+                    tmpRect.copy(list[i].getBoundingRect());
+                    if (list[i].transform) {
+                        tmpRect.applyTransform(list[i].transform);
+                    }
+                    if (tmpRect.intersect(pointerRect)) {
                         candidates.push(list[i]);
                     }
                 }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -147,6 +147,8 @@ class Handler extends Eventful {
 
     private _draggingMgr: Draggable
 
+    private _targetSize: number
+
     _downEl: Element
     _upEl: Element
     _downPoint: [number, number]
@@ -155,7 +157,8 @@ class Handler extends Eventful {
         storage: Storage,
         painter: PainterBase,
         proxy: HandlerProxyInterface,
-        painterRoot: HTMLElement
+        painterRoot: HTMLElement,
+        targetSize: number
     ) {
         super();
 
@@ -164,6 +167,8 @@ class Handler extends Eventful {
         this.painter = painter;
 
         this.painterRoot = painterRoot;
+
+        this._targetSize = targetSize;
 
         proxy = proxy || new EmptyProxy();
 
@@ -354,13 +359,13 @@ class Handler extends Eventful {
             }
         }
 
-        if (!out.target) {
+        if (this._targetSize && !out.target) {
             /**
              * If no element at pointer position, check intersection with
              * elements with pointer enlarged by target size.
              */
             const candidates = [];
-            const targetSize = 44;
+            const targetSize = this._targetSize;
             const targetSizeHalf = targetSize / 2;
             const pointerRect = new BoundingRect(x - targetSizeHalf, y - targetSizeHalf, targetSize, targetSize);
             for (let i = list.length - 1; i >= 0; i--) {

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -387,9 +387,9 @@ class Handler extends Eventful {
                         for (let i = 0; i < candidates.length; i++) {
                             const hoverCheckResult = isHover(candidates[i], x1, y1);
                             if (hoverCheckResult) {
-                                !out.topTarget && (out.topTarget = list[i]);
+                                !out.topTarget && (out.topTarget = candidates[i]);
                                 if (hoverCheckResult !== SILENT) {
-                                    out.target = list[i];
+                                    out.target = candidates[i];
                                     break;
                                 }
                             }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -11,6 +11,7 @@ import { ZRRawEvent, ZRPinchEvent, ElementEventName, ElementEventNameWithOn, ZRR
 import Storage from './Storage';
 import Element, {ElementEvent} from './Element';
 import CanvasPainter from './canvas/Painter';
+import { BoundingRect } from './export';
 
 
 /**
@@ -349,6 +350,27 @@ class Handler extends Eventful {
                 if (hoverCheckResult !== SILENT) {
                     out.target = list[i];
                     break;
+                }
+            }
+        }
+
+        if (!out.target) {
+            // If no element at pointer position, increase targetSize
+            const targetSize = 44;
+            let minSize = Number.MAX_VALUE;
+            for (let i = list.length - 1; i >= 0; i--) {
+                const rect = list[i].getBoundingRect();
+                const size = Math.min(rect.width, rect.height);
+                if (
+                    list[i] !== exclude
+                    && !list[i].ignore
+                    && !list[i].silent
+                    && size < targetSize
+                    && size < minSize
+                    && list[i].targetSizeContain(x, y, targetSize)
+                ) {
+                    out.target = list[i];
+                    minSize = size;
                 }
             }
         }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -354,7 +354,6 @@ class Handler extends Eventful {
             }
         }
 
-        // console.time('targetSize');
         if (!out.target) {
             /**
              * If no element at pointer position, check intersection with
@@ -367,7 +366,7 @@ class Handler extends Eventful {
             for (let i = list.length - 1; i >= 0; i--) {
                 if (list[i] !== exclude
                     && !list[i].ignore
-                    && !list[i].silent
+                    && !list[i].ignoreTargetSize
                 ) {
                     const rect = list[i].getBoundingRect().clone();
                     rect.applyTransform(list[i].transform);
@@ -398,7 +397,6 @@ class Handler extends Eventful {
                 }
             }
         }
-        // console.timeEnd('targetSize');
 
         return out;
     }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -160,7 +160,7 @@ class Handler extends Eventful {
         painter: PainterBase,
         proxy: HandlerProxyInterface,
         painterRoot: HTMLElement,
-        targetSize: number
+        pointerSize: number
     ) {
         super();
 
@@ -170,7 +170,7 @@ class Handler extends Eventful {
 
         this.painterRoot = painterRoot;
 
-        this._pointerSize = targetSize;
+        this._pointerSize = pointerSize;
 
         proxy = proxy || new EmptyProxy();
 
@@ -386,6 +386,10 @@ class Handler extends Eventful {
                 }
             }
 
+            /**
+             * If there are elements whose bounding boxes are near the pointer,
+             * use the most top one that intersects with the enlarged pointer.
+             */
             if (candidates.length) {
                 const rStep = 4;
                 const thetaStep = Math.PI / 12;

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -374,7 +374,7 @@ class Handler extends Eventful {
             for (let i = list.length - 1; i >= 0; i--) {
                 if (list[i] !== exclude
                     && !list[i].ignore
-                    && !list[i].ignoreTargetSize
+                    && !list[i].ignoreCoarsePointer
                 ) {
                     tmpRect.copy(list[i].getBoundingRect());
                     if (list[i].transform) {

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -147,7 +147,7 @@ class Handler extends Eventful {
 
     private _draggingMgr: Draggable
 
-    private _targetSize: number
+    private _pointerSize: number
 
     _downEl: Element
     _upEl: Element
@@ -168,7 +168,7 @@ class Handler extends Eventful {
 
         this.painterRoot = painterRoot;
 
-        this._targetSize = targetSize;
+        this._pointerSize = targetSize;
 
         proxy = proxy || new EmptyProxy();
 
@@ -359,15 +359,15 @@ class Handler extends Eventful {
             }
         }
 
-        if (this._targetSize && !out.target) {
+        if (this._pointerSize && !out.target) {
             /**
              * If no element at pointer position, check intersection with
              * elements with pointer enlarged by target size.
              */
             const candidates = [];
-            const targetSize = this._targetSize;
-            const targetSizeHalf = targetSize / 2;
-            const pointerRect = new BoundingRect(x - targetSizeHalf, y - targetSizeHalf, targetSize, targetSize);
+            const pointerSize = this._pointerSize;
+            const targetSizeHalf = pointerSize / 2;
+            const pointerRect = new BoundingRect(x - targetSizeHalf, y - targetSizeHalf, pointerSize, pointerSize);
             for (let i = list.length - 1; i >= 0; i--) {
                 if (list[i] !== exclude
                     && !list[i].ignore

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -375,6 +375,10 @@ class Handler extends Eventful {
                 if (list[i] !== exclude
                     && !list[i].ignore
                     && !list[i].ignoreCoarsePointer
+                    // If an element ignores, its textContent should also ignore.
+                    // TSpan's parent is not a Group but a ZRText.
+                    // See Text.js _getOrCreateChild
+                    && (!list[i].parent || !(list[i].parent as any).ignoreCoarsePointer)
                 ) {
                     tmpRect.copy(list[i].getBoundingRect());
                     if (list[i].transform) {

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -347,15 +347,16 @@ class Handler extends Eventful {
         const out = new HoveredResult(x, y);
 
         for (let i = list.length - 1; i >= 0; i--) {
+            const el = list[i];
             let hoverCheckResult;
-            if (list[i] !== exclude
+            if (el !== exclude
                 // getDisplayList may include ignored item in VML mode
-                && !list[i].ignore
-                && (hoverCheckResult = isHover(list[i], x, y))
+                && !el.ignore
+                && (hoverCheckResult = isHover(el, x, y))
             ) {
-                !out.topTarget && (out.topTarget = list[i]);
+                !out.topTarget && (out.topTarget = el);
                 if (hoverCheckResult !== SILENT) {
-                    out.target = list[i];
+                    out.target = el;
                     break;
                 }
             }
@@ -372,20 +373,21 @@ class Handler extends Eventful {
             const pointerRect = new BoundingRect(x - targetSizeHalf, y - targetSizeHalf, pointerSize, pointerSize);
 
             for (let i = list.length - 1; i >= 0; i--) {
-                if (list[i] !== exclude
-                    && !list[i].ignore
-                    && !list[i].ignoreCoarsePointer
+                const el = list[i];
+                if (el !== exclude
+                    && !el.ignore
+                    && !el.ignoreCoarsePointer
                     // If an element ignores, its textContent should also ignore.
                     // TSpan's parent is not a Group but a ZRText.
                     // See Text.js _getOrCreateChild
-                    && (!list[i].parent || !(list[i].parent as any).ignoreCoarsePointer)
+                    && (!el.parent || !(el.parent as any).ignoreCoarsePointer)
                 ) {
-                    tmpRect.copy(list[i].getBoundingRect());
-                    if (list[i].transform) {
-                        tmpRect.applyTransform(list[i].transform);
+                    tmpRect.copy(el.getBoundingRect());
+                    if (el.transform) {
+                        tmpRect.applyTransform(el.transform);
                     }
                     if (tmpRect.intersect(pointerRect)) {
-                        candidates.push(list[i]);
+                        candidates.push(el);
                     }
                 }
             }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -384,11 +384,14 @@ class Handler extends Eventful {
             if (candidates.length) {
                 const rStep = 4;
                 const thetaStep = Math.PI / 12;
-                for (let r = 0; r < targetSizeHalf && !out.target; r += rStep) {
-                    for (let theta = 0; theta < Math.PI * 2 && !out.target; theta += thetaStep) {
+                for (let r = 0; r < targetSizeHalf; r += rStep) {
+                    for (let theta = 0; theta < Math.PI * 2; theta += thetaStep) {
                         const x1 = x + r * Math.cos(theta);
                         const y1 = y + r * Math.sin(theta);
                         setHoverTarget(candidates, out, x1, y1, exclude);
+                        if (out.target) {
+                            return out;
+                        }
                     }
                 }
             }

--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -11,8 +11,7 @@ import { ZRRawEvent, ZRPinchEvent, ElementEventName, ElementEventNameWithOn, ZRR
 import Storage from './Storage';
 import Element, {ElementEvent} from './Element';
 import CanvasPainter from './canvas/Painter';
-import { BoundingRect } from './export';
-
+import BoundingRect from './core/BoundingRect';
 
 /**
  * [The interface between `Handler` and `HandlerProxy`]:
@@ -384,8 +383,9 @@ class Handler extends Eventful {
             if (candidates.length) {
                 const rStep = 4;
                 const thetaStep = Math.PI / 12;
+                const PI2 = Math.PI * 2;
                 for (let r = 0; r < targetSizeHalf; r += rStep) {
-                    for (let theta = 0; theta < Math.PI * 2; theta += thetaStep) {
+                    for (let theta = 0; theta < PI2; theta += thetaStep) {
                         const x1 = x + r * Math.cos(theta);
                         const y1 = y + r * Math.sin(theta);
                         setHoverTarget(candidates, out, x1, y1, exclude);

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -309,6 +309,9 @@ export function isMiddleOrRightButtonOnMouseUpDown(e: { which: number }) {
     return e.which === 2 || e.which === 3;
 }
 
+export function isTouchDevice() {
+    return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+}
 
 // For backward compatibility
 export {Eventful as Dispatcher};

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -310,7 +310,8 @@ export function isMiddleOrRightButtonOnMouseUpDown(e: { which: number }) {
 }
 
 export function isTouchDevice() {
-    return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+    return (typeof window === 'object' && 'ontouchstart' in window)
+        || (typeof navigator === 'object' && navigator.maxTouchPoints > 0);
 }
 
 // For backward compatibility

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -309,10 +309,5 @@ export function isMiddleOrRightButtonOnMouseUpDown(e: { which: number }) {
     return e.which === 2 || e.which === 3;
 }
 
-export function isTouchDevice() {
-    return (typeof window === 'object' && 'ontouchstart' in window)
-        || (typeof navigator === 'object' && navigator.maxTouchPoints > 0);
-}
-
 // For backward compatibility
 export {Eventful as Dispatcher};

--- a/src/graphic/Displayable.ts
+++ b/src/graphic/Displayable.ts
@@ -260,6 +260,29 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
         return rect.contain(coord[0], coord[1]);
     }
 
+    /**
+     * If a given targetSize is set, does the element contain the coord x, y
+     *
+     * @param x global x position
+     * @param y global y position
+     * @param targetSize tolerance of the touch position
+     * @returns true if the element contains the coord x, y
+     */
+    targetSizeContain(x: number, y: number, targetSize: number): boolean {
+        const rect = this.getBoundingRect().clone();
+        if (rect.width === 0 || rect.height === 0) {
+            return false;
+        }
+
+        rect.applyTransform(this.transform);
+        return rect.intersect(new BoundingRect(
+            x - targetSize / 2,
+            y - targetSize / 2,
+            targetSize,
+            targetSize
+        ));
+    }
+
     getPaintRect(): BoundingRect {
         let rect = this._paintRect;
         if (!this._paintRect || this.__dirty) {

--- a/src/graphic/Displayable.ts
+++ b/src/graphic/Displayable.ts
@@ -260,29 +260,6 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
         return rect.contain(coord[0], coord[1]);
     }
 
-    /**
-     * If a given targetSize is set, does the element contain the coord x, y
-     *
-     * @param x global x position
-     * @param y global y position
-     * @param targetSize tolerance of the touch position
-     * @returns true if the element contains the coord x, y
-     */
-    targetSizeContain(x: number, y: number, targetSize: number): boolean {
-        const rect = this.getBoundingRect().clone();
-        if (rect.width === 0 || rect.height === 0) {
-            return false;
-        }
-
-        rect.applyTransform(this.transform);
-        return rect.intersect(new BoundingRect(
-            x - targetSize / 2,
-            y - targetSize / 2,
-            targetSize,
-            targetSize
-        ));
-    }
-
     getPaintRect(): BoundingRect {
         let rect = this._paintRect;
         if (!this._paintRect || this.__dirty) {

--- a/src/graphic/Displayable.ts
+++ b/src/graphic/Displayable.ts
@@ -66,6 +66,8 @@ export interface DisplayableProps extends ElementProps {
 
     incremental?: boolean
 
+    ignoreTargetSize?: boolean
+
     batch?: boolean
     invisible?: boolean
 }
@@ -126,6 +128,11 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
      * For increamental rendering
      */
     incremental: boolean
+
+    /**
+     * Never increase to target size
+     */
+    ignoreTargetSize?: boolean
 
     style: Dictionary<any>
 

--- a/src/graphic/Displayable.ts
+++ b/src/graphic/Displayable.ts
@@ -66,7 +66,7 @@ export interface DisplayableProps extends ElementProps {
 
     incremental?: boolean
 
-    ignoreTargetSize?: boolean
+    ignoreCoarsePointer?: boolean
 
     batch?: boolean
     invisible?: boolean
@@ -132,7 +132,7 @@ class Displayable<Props extends DisplayableProps = DisplayableProps> extends Ele
     /**
      * Never increase to target size
      */
-    ignoreTargetSize?: boolean
+    ignoreCoarsePointer?: boolean
 
     style: Dictionary<any>
 

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -128,12 +128,12 @@ class ZRender {
             ? new HandlerProxy(painter.getViewportRoot(), painter.root)
             : null;
 
-        const useTargetSize = (opts.useTargetSize == null || opts.useTargetSize === 'auto')
+        const useTargetSize = (opts.useCoarsePointer == null || opts.useCoarsePointer === 'auto')
             ? isTouchDevice()
-            : !!opts.useTargetSize;
+            : !!opts.useCoarsePointer;
         const defaultTargetSize = 44;
         const targetSize = useTargetSize
-            ? (opts.targetSize == null ? defaultTargetSize : opts.targetSize)
+            ? (opts.pointerSize == null ? defaultTargetSize : opts.pointerSize)
             : 0;
 
         this.handler = new Handler(storage, painter, handerProxy, painter.root, targetSize);
@@ -435,8 +435,8 @@ export interface ZRenderInitOpt {
     width?: number | string // 10, 10px, 'auto'
     height?: number | string
     useDirtyRect?: boolean
-    useTargetSize?: 'auto' | boolean
-    targetSize?: number
+    useCoarsePointer?: 'auto' | boolean
+    pointerSize?: number
     ssr?: boolean   // If enable ssr mode.
 }
 

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -25,6 +25,7 @@ import Displayable from './graphic/Displayable';
 import { lum } from './tool/color';
 import { DARK_MODE_THRESHOLD } from './config';
 import Group from './graphic/Group';
+import { isTouchDevice } from './core/event';
 
 
 type PainterBaseCtor = {
@@ -126,7 +127,16 @@ class ZRender {
         const handerProxy = (!env.node && !env.worker && !ssrMode)
             ? new HandlerProxy(painter.getViewportRoot(), painter.root)
             : null;
-        this.handler = new Handler(storage, painter, handerProxy, painter.root);
+
+        const useTargetSize = (opts.useTargetSize == null || opts.useTargetSize === 'auto')
+            ? isTouchDevice()
+            : !!opts.useTargetSize;
+        const defaultTargetSize = 44;
+        const targetSize = useTargetSize
+            ? (opts.targetSize == null ? defaultTargetSize : opts.targetSize)
+            : 0;
+
+        this.handler = new Handler(storage, painter, handerProxy, painter.root, targetSize);
 
         this.animation = new Animation({
             stage: {
@@ -425,6 +435,8 @@ export interface ZRenderInitOpt {
     width?: number | string // 10, 10px, 'auto'
     height?: number | string
     useDirtyRect?: boolean
+    useTargetSize?: 'auto' | boolean
+    targetSize?: number
     ssr?: boolean   // If enable ssr mode.
 }
 

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -131,6 +131,7 @@ class ZRender {
         const useTargetSize = (opts.useCoarsePointer == null || opts.useCoarsePointer === 'auto')
             ? isTouchDevice()
             : !!opts.useCoarsePointer;
+        console.log(useTargetSize)
         const defaultTargetSize = 44;
         const targetSize = useTargetSize
             ? (opts.pointerSize == null ? defaultTargetSize : opts.pointerSize)

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -25,7 +25,6 @@ import Displayable from './graphic/Displayable';
 import { lum } from './tool/color';
 import { DARK_MODE_THRESHOLD } from './config';
 import Group from './graphic/Group';
-import { isTouchDevice } from './core/event';
 
 
 type PainterBaseCtor = {
@@ -130,14 +129,15 @@ class ZRender {
 
         const useCoarsePointer = opts.useCoarsePointer;
         const usePointerSize = (useCoarsePointer == null || useCoarsePointer === 'auto')
-            ? isTouchDevice()
+            ? env.touchEventsSupported
             : !!useCoarsePointer;
         const defaultPointerSize = 44;
-        const targetSize = usePointerSize
-            ? (opts.pointerSize == null ? defaultPointerSize : opts.pointerSize)
-            : 0;
+        let pointerSize;
+        if (usePointerSize) {
+            pointerSize = zrUtil.retrieve2(opts.pointerSize, defaultPointerSize);
+        }
 
-        this.handler = new Handler(storage, painter, handerProxy, painter.root, targetSize);
+        this.handler = new Handler(storage, painter, handerProxy, painter.root, pointerSize);
 
         this.animation = new Animation({
             stage: {

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -131,7 +131,6 @@ class ZRender {
         const useTargetSize = (opts.useCoarsePointer == null || opts.useCoarsePointer === 'auto')
             ? isTouchDevice()
             : !!opts.useCoarsePointer;
-        console.log(useTargetSize)
         const defaultTargetSize = 44;
         const targetSize = useTargetSize
             ? (opts.pointerSize == null ? defaultTargetSize : opts.pointerSize)

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -128,12 +128,13 @@ class ZRender {
             ? new HandlerProxy(painter.getViewportRoot(), painter.root)
             : null;
 
-        const useTargetSize = (opts.useCoarsePointer == null || opts.useCoarsePointer === 'auto')
+        const useCoarsePointer = opts.useCoarsePointer;
+        const usePointerSize = (useCoarsePointer == null || useCoarsePointer === 'auto')
             ? isTouchDevice()
-            : !!opts.useCoarsePointer;
-        const defaultTargetSize = 44;
-        const targetSize = useTargetSize
-            ? (opts.pointerSize == null ? defaultTargetSize : opts.pointerSize)
+            : !!useCoarsePointer;
+        const defaultPointerSize = 44;
+        const targetSize = usePointerSize
+            ? (opts.pointerSize == null ? defaultPointerSize : opts.pointerSize)
             : 0;
 
         this.handler = new Handler(storage, painter, handerProxy, painter.root, targetSize);

--- a/test/coarse-pointer.html
+++ b/test/coarse-pointer.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../dist/zrender.js"></script>
+</head>
+<body>
+    <style>
+        html {
+            margin: 0;
+            padding: 0;
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+        .chart {
+            height: 800px;
+        }
+        h1 {
+            background: #000;
+            color: #eee;
+            font-size: 18px;
+            text-align: center;
+            padding: 10px;
+            margin: 0 0 10px 0;
+        }
+    </style>
+
+    <h1>
+        Open mobile debug mode and then touch. The green circles should make a color to be lighter while the red circles should not.
+    </h1>
+    <div id="main0" class="chart"></div>
+
+
+    <script type="text/javascript">
+    (function () {
+        var zr = zrender.init(document.getElementById('main0'), {
+            useCoarsePointer: 'auto',
+            pointerSize: 44
+        });
+
+        var rect = new zrender.Rect({
+            shape: {
+                x: 170,
+                y: 110,
+                width: 50,
+                height: 50
+            },
+            style: {
+                fill: '#007'
+            }
+        });
+        zr.add(rect);
+
+        rect.on('mouseover', function () {
+            rect.attr('style', {
+                fill: '#06f'
+            });
+        });
+
+        rect.on('mouseout', function () {
+            rect.attr('style', {
+                fill: '#007'
+            });
+        });
+
+        var circle = new zrender.Circle({
+            style: {
+                fill: 'green',
+            },
+            shape: {
+                cx: 180,
+                cy: 95,
+                r: 5
+            },
+            textContent: new zrender.Text({
+                style: {
+                    text: '1. Enable mobile debugging mode in your browser.\n2. Touch around the green circles.\n3. Expect the blue shape to be a lighter blue.',
+                    fontSize: 12
+                }
+            }),
+            textConfig: {
+                position: 'top'
+            },
+            silent: true
+        });
+        zr.add(circle);
+
+        circle = new zrender.Circle({
+            style: {
+                fill: 'red',
+            },
+            shape: {
+                cx: 260,
+                cy: 180,
+                r: 5
+            },
+            textContent: new zrender.Text({
+                style: {
+                    text: '4. Touch around the red circles.\n5. Expect the blue shape not to change.',
+                    fontSize: 12
+                }
+            }),
+            textConfig: {
+                position: 'bottom'
+            },
+            silent: true
+        });
+        zr.add(circle);
+
+
+        var path = new zrender.Polygon({
+            shape: {
+                points: [
+                    [100, 250],
+                    [170, 340],
+                    [300, 220],
+                    [200, 400],
+                    [100, 300]
+                ]
+            },
+            style: {
+                fill: '#007'
+            }
+        });
+        zr.add(path);
+
+        path.on('mouseover', function () {
+            path.attr('style', {
+                fill: '#06f'
+            });
+        });
+
+        path.on('mouseout', function () {
+            path.attr('style', {
+                fill: '#007'
+            });
+        });
+
+        zr.add(new zrender.Circle({
+            style: {
+                fill: 'red',
+            },
+            shape: {
+                cx: 160,
+                cy: 270,
+                r: 5
+            },
+            silent: true
+        }));
+
+        zr.add(new zrender.Circle({
+            style: {
+                fill: 'green',
+            },
+            shape: {
+                cx: 180,
+                cy: 310,
+                r: 5
+            },
+            silent: true
+        }));
+
+        var rect2 = new zrender.Rect({
+            shape: {
+                x: 170,
+                y: 450,
+                width: 50,
+                height: 50
+            },
+            style: {
+                fill: '#700'
+            },
+            textContent: new zrender.Text({
+                style: {
+                    text: 'This is a shape with `ignoreCoarsePointer`.\nIt will NOT be affected by `useCoarsePointer`.',
+                    fontSize: 12
+                },
+                ignoreCoarsePointer: true
+            }),
+            textConfig: {
+                position: 'bottom'
+            },
+            ignoreCoarsePointer: true
+        });
+        rect2.ignoreCoarsePointer = true;
+        zr.add(rect2);
+
+        rect2.on('mouseover', function () {
+            rect2.attr('style', {
+                fill: '#f00'
+            });
+        });
+
+        rect2.on('mouseout', function () {
+            rect2.attr('style', {
+                fill: '#700'
+            });
+        });
+
+        zr.add(new zrender.Circle({
+            style: {
+                fill: 'green',
+            },
+            shape: {
+                cx: 200,
+                cy: 470,
+                r: 5
+            },
+            silent: true
+        }));
+        zr.add(new zrender.Circle({
+            style: {
+                fill: 'green',
+            },
+            shape: {
+                cx: 200,
+                cy: 520,
+                r: 5
+            },
+            silent: true
+        }));
+        zr.add(new zrender.Circle({
+            style: {
+                fill: 'red',
+            },
+            shape: {
+                cx: 235,
+                cy: 470,
+                r: 5
+            },
+            silent: true
+        }));
+        zr.add(new zrender.Circle({
+            style: {
+                fill: 'red',
+            },
+            shape: {
+                cx: 200,
+                cy: 540,
+                r: 5
+            },
+            silent: true
+        }));
+    })();
+    </script>
+
+
+
+
+
+
+
+</body>
+</html>

--- a/test/coarse-pointer.html
+++ b/test/coarse-pointer.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="../dist/zrender.js"></script>
+    <script src="lib/config.js"></script>
 </head>
 <body>
     <style>
@@ -31,14 +32,16 @@
     <h1>
         Open mobile debug mode and then touch. The green circles should make a color to be lighter while the red circles should not.
     </h1>
+
+    Open this case with <a href="?__COARSE__POINTER__=true">?__COARSE__POINTER__=true</a>.
+
     <div id="main0" class="chart"></div>
 
 
     <script type="text/javascript">
     (function () {
         var zr = zrender.init(document.getElementById('main0'), {
-            useCoarsePointer: 'auto',
-            pointerSize: 44
+            useCoarsePointer: window.__ZRENDER__DEFAULT__COARSE_POINTER
         });
 
         var rect = new zrender.Rect({
@@ -77,7 +80,7 @@
             },
             textContent: new zrender.Text({
                 style: {
-                    text: '1. Enable mobile debugging mode in your browser.\n2. Touch around the green circles.\n3. Expect the blue shape to be a lighter blue.',
+                    text: '1. Touch around the green circles.\n2. Expect the blue shape to be a lighter blue.',
                     fontSize: 12
                 }
             }),
@@ -99,7 +102,7 @@
             },
             textContent: new zrender.Text({
                 style: {
-                    text: '4. Touch around the red circles.\n5. Expect the blue shape not to change.',
+                    text: '3. Touch around the red circles.\n4. Expect the blue shape not to change.',
                     fontSize: 12
                 }
             }),

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -6,9 +6,19 @@
     sourceMap == null && (sourceMap = true);
 
     // Set default renderer in dev mode from hash.
-    var matchResult = location.href.match(/[?&]__RENDERER__=(canvas|svg)(&|$)/);
-    if (matchResult) {
-        window.__ZRENDER__DEFAULT__RENDERER__ = matchResult[1];
+    var rendererMatchResult = location.href.match(/[?&]__RENDERER__=(canvas|svg)(&|$)/);
+    if (rendererMatchResult) {
+        window.__ZRENDER__DEFAULT__RENDERER__ = rendererMatchResult[1];
+    }
+
+    var coarsePointerMatchResult = location.href.match(/[?&]__COARSE__POINTER__=(true|false|auto)(&|$)/);
+    if (coarsePointerMatchResult) {
+        window.__ZRENDER__DEFAULT__COARSE_POINTER =
+            coarsePointerMatchResult[1] === 'true'
+                ? true
+                : coarsePointerMatchResult[1] === 'false'
+                    ? false
+                    : 'auto';
     }
 
     if (typeof require !== 'undefined') {

--- a/test/lib/testHelper.js
+++ b/test/lib/testHelper.js
@@ -5,9 +5,19 @@
 
 
     // Set default renderer in dev mode from hash.
-    var matchResult = location.href.match(/[?&]__RENDERER__=(canvas|svg)(&|$)/);
-    if (matchResult) {
-        window.__ZRENDER__DEFAULT__RENDERER__ = matchResult[1];
+    var rendererMatchResult = location.href.match(/[?&]__RENDERER__=(canvas|svg)(&|$)/);
+    if (rendererMatchResult) {
+        window.__ZRENDER__DEFAULT__RENDERER__ = rendererMatchResult[1];
+    }
+
+    var coarsePointerMatchResult = location.href.match(/[?&]__COARSE__POINTER__=(true|false|auto)(&|$)/);
+    if (coarsePointerMatchResult) {
+        window.__ZRENDER__DEFAULT__COARSE_POINTER =
+            coarsePointerMatchResult[1] === 'true'
+                ? true
+                : coarsePointerMatchResult[1] === 'false'
+                    ? false
+                    : 'auto';
     }
 
     // ----------------------------


### PR DESCRIPTION
### Intent

This PR is intended to increase elements' responsive area on mobile devices so that elements can be touched more easily.

The idea is inspired by W3C's [Understanding Success Criterion 2.5.5: Target Size](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html).

### Algorithm

The algorithm can be briefly described as:

1. Find the hovering element at the pointer position. If it exists, return the hovering element. Otherwise, go to 2.
2. Calculate the elements whose bounding boxes have intersection with the touch position enlarged by "pointerSize" (which is 44px by default)
3. Loop through different radius and angle from the pointer position to check if there are elements intersecting with it.

For cases that have too many elements, this feature can be turned off by setting `ignoreCoarsePointer` to the elements.

Tested with the Apache ECharts test cases and in most cases the extra calculation time is under 0.1ms.

### API

```ts
zrender.init({
  useCoarsePointer: 'auto',
  pointerSize: 44,
  ...
});
```

- `useCoarsePointer` (`'auto'` | `true` | `false`): whether to enable thie feature. If set to be `'auto'`, it's turned on only for mobile devices.
- `pointerSize` (`number`): pointer position is increased by this size in diameter.

Each element can be set with `ignoreCoarsePointer` to turn off this feature individually:

```ts
el.ignoreCoarsePointer = true;
```
