### PR TITLE
fix(gradient): #898 has bug about safe checkingand breaks all gradients

### DIFF
--- a/src/canvas/helper.ts
+++ b/src/canvas/helper.ts
@@ -6,7 +6,7 @@ import Path from '../graphic/Path';
 
 function isSafeNum(num: number) {
     // NaN、Infinity、undefined、'xx'
-    return !isFinite(num);
+    return isFinite(num);
 }
 
 export function createLinearGradient(


### PR DESCRIPTION
#898 tries to fix the problem of invalid input with gradients but it seems to get wrong results when checking if a number is safe. It caused all gradients to break down in Apache ECharts.

I also tested with the case of https://github.com/apache/echarts/issues/16649 and #898 's fixing didn't work but after this PR's fixing it works.