### PR TITLE
fix: parse rgb but gives rgba value

### DIFF
--- a/src/tool/color.ts
+++ b/src/tool/color.ts
@@ -245,7 +245,8 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
                     );
                     putToCache(colorStr, rgbaArr);
                     return rgbaArr;
-                } else {
+                }
+                else {
                     setRgba(rgbaArr, 0, 0, 0, 1);
                     return;
                 }

--- a/src/tool/color.ts
+++ b/src/tool/color.ts
@@ -236,18 +236,19 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
                 alpha = parseCssFloat(params.pop() as string); // jshint ignore:line
             // Fall through.
             case 'rgb':
-                if (params.length !== 3) {
+                if (params.length === 3 || params.length === 4) {
+                    setRgba(rgbaArr,
+                        parseCssInt(params[0]),
+                        parseCssInt(params[1]),
+                        parseCssInt(params[2]),
+                        alpha
+                    );
+                    putToCache(colorStr, rgbaArr);
+                    return rgbaArr;
+                } else {
                     setRgba(rgbaArr, 0, 0, 0, 1);
                     return;
                 }
-                setRgba(rgbaArr,
-                    parseCssInt(params[0]),
-                    parseCssInt(params[1]),
-                    parseCssInt(params[2]),
-                    alpha
-                );
-                putToCache(colorStr, rgbaArr);
-                return rgbaArr;
             case 'hsla':
                 if (params.length !== 4) {
                     setRgba(rgbaArr, 0, 0, 0, 1);

--- a/test/ut/spec/tool/color.test.ts
+++ b/test/ut/spec/tool/color.test.ts
@@ -1,5 +1,4 @@
 import * as colorTool from '../../../../src/tool/color';
-import { color } from '../../../../src/export';
 
 describe('colorTool', function () {
 
@@ -7,6 +6,7 @@ describe('colorTool', function () {
 		['rgba(17, 163, 69)', [17, 163, 69, 1]],
 		['rgba(17, 163, 69, 0.5)', [17, 163, 69, 0.5]],
 		['rgb(17, 163, 69)', [17, 163, 69, 1]],
+		['rgb(2, 163, 254, 1)', [2, 163, 254, 1]],
 		['#14c4ba00', [20, 196, 186, 0]],
 		['#14c4ba', [20, 196, 186, 1]],
 		['#07f0', [0, 119, 255, 0]],


### PR DESCRIPTION
解析rgb颜色时能兼容处理 rgb(2,163,254,1)格式