### PR TITLE
feat(color): suport color space syntax

### DIFF
--- a/src/tool/color.ts
+++ b/src/tool/color.ts
@@ -180,6 +180,13 @@ export function parse(colorStr: string, rgbaArr?: number[]): number[] {
         return rgbaArr;
     }
 
+    // check for the <color> syntax,
+    // https://drafts.csswg.org/css-color/#color-syntax
+    if (/\(\S*\s\S*\s\S*/.test(colorStr)) {
+        colorStr = colorStr.replace(/\s\/\s/, ' ');
+        str = colorStr.replace(/ /g, ',');
+    }
+
     // supports the forms #rgb, #rrggbb, #rgba, #rrggbbaa
     // #rrggbbaa(use the last pair of digits as alpha)
     // see https://drafts.csswg.org/css-color/#hex-notation


### PR DESCRIPTION
new feature for [color-syntax](https://drafts.csswg.org/css-color/#color-syntax)

> For easy reference in other specifications, opaque black is defined as the color rgb(0 0 0 / 100%); transparent black is the same color, but fully transparent—i.e. rgb(0 0 0 / 0%).
> All of the [<color>](https://drafts.csswg.org/css-color/#typedef-color) syntactic forms defined in this specification use space, not comma, to separate the color components. They also use a solidus ("/") to separate an optional alpha term from the color components.

example: 
```
rgb(254 134 22)
rgb(254 134 22 / 20%)
rgba(154 234 222 / 20%)
hsl(120 75% 50%)
hsl(120 75% 50% / 0.25)
hsla(120.0 75% 50% / 25%)
```