### PR TITLE
fix(svg): encode HTML when converting vnode to string.

### DIFF
--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -1,6 +1,7 @@
 
 import env from './env';
 import {buildTransformer} from './fourPointsTransform';
+import {Dictionary} from './types';
 
 const EVENT_SAVED_PROP = '___zrEVENTSAVED';
 const _calcOut: number[] = [];
@@ -166,4 +167,21 @@ function preparePointerTransformer(markers: HTMLDivElement[], saved: SavedInfo, 
 
 export function isCanvasEl(el: HTMLElement): el is HTMLCanvasElement {
     return el.nodeName.toUpperCase() === 'CANVAS';
+}
+
+const replaceReg = /([&<>"'])/g;
+const replaceMap: Dictionary<string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    '\'': '&#39;'
+};
+
+export function encodeHTML(source: string): string {
+    return source == null
+        ? ''
+        : (source + '').replace(replaceReg, function (str, c) {
+            return replaceMap[c];
+        });
 }

--- a/src/svg/core.ts
+++ b/src/svg/core.ts
@@ -1,4 +1,5 @@
 import { keys, map } from '../core/util';
+import { encodeHTML } from '../core/dom';
 
 export type CSSSelectorVNode = Record<string, string>
 export type CSSAnimationVNode = Record<string, Record<string, string>>
@@ -71,7 +72,7 @@ export function vNodeToString(el: SVGVNode, opts?: {
     function convertElToString(el: SVGVNode): string {
         const {children, tag, attrs} = el;
         return createElementOpen(tag, attrs)
-            + (el.text || '')
+            + encodeHTML(el.text)
             + (children ? `${S}${map(children, child => convertElToString(child)).join(S)}${S}` : '')
             + createElementClose(tag);
     }


### PR DESCRIPTION
Fix apache/echarts#17399

Since we don't encode the SVG string, the generated SVG may be broken if it contains special characters.

And the `encodeHTML` function was moved from `echarts` to `zrender` in this PR.