### PR TITLE
fix(canvas): fix pattern is not correctly scaled in canvas renderer

### DIFF
--- a/src/canvas/Layer.ts
+++ b/src/canvas/Layer.ts
@@ -435,6 +435,9 @@ export default class Layer extends Eventful {
                 }
                 // Pattern
                 else if (util.isImagePatternObject(clearColor)) {
+                    // scale pattern by dpr
+                    clearColor.scaleX = util.retrieve2(clearColor.scaleX, dpr);
+                    clearColor.scaleY = util.retrieve2(clearColor.scaleY, dpr);
                     clearColorGradientOrPattern = createCanvasPattern(
                         ctx, clearColor, {
                             dirty() {
@@ -476,7 +479,7 @@ export default class Layer extends Eventful {
         }
     }
 
-    // Iterface of refresh
+    // Interface of refresh
     refresh: (clearColor?: string | GradientObject | ImagePatternObject) => void
 
     // Interface of renderToCanvas in getRenderedCanvas

--- a/src/canvas/Layer.ts
+++ b/src/canvas/Layer.ts
@@ -436,8 +436,8 @@ export default class Layer extends Eventful {
                 // Pattern
                 else if (util.isImagePatternObject(clearColor)) {
                     // scale pattern by dpr
-                    clearColor.scaleX = util.retrieve2(clearColor.scaleX, dpr);
-                    clearColor.scaleY = util.retrieve2(clearColor.scaleY, dpr);
+                    clearColor.scaleX = clearColor.scaleX || dpr;
+                    clearColor.scaleY = clearColor.scaleY || dpr;
                     clearColorGradientOrPattern = createCanvasPattern(
                         ctx, clearColor, {
                             dirty() {

--- a/test/pattern-transform.html
+++ b/test/pattern-transform.html
@@ -50,6 +50,10 @@
                 }
             });
             zr.add(rect);
+            zr.setBackgroundColor({
+                image: image,
+                repeat: 'no-repeat'
+            });
         };
         image.src = './asset/test.png';
 


### PR DESCRIPTION
When setting an image as the background color, the canvas renderer doesn't scale it by the device pixel ratio, which results in the pattern effect being different from the effect in the SVG renderer.

| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/26999792/180654538-59c7aea5-3ff5-47bb-8eb1-25116a60a1b9.png) | ![image](https://user-images.githubusercontent.com/26999792/180654491-12bf478c-da91-4b5c-8242-090ea2d01397.png) |

Note that the size of the background image is _180px×180px_ 👆