### PR TITLE
fix(morph): fix shape may disappear after morphing animation is finished in SVG renderer

### DIFF
--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -170,12 +170,13 @@ export function brushSVGPath(el: Path, scope: BrushScope) {
         builtinShpDef[0](shape, attrs, mul);
     }
     else {
+        const needBuildPath = !el.path || el.shapeChanged();
         if (!el.path) {
             el.createPathProxy();
         }
         const path = el.path;
 
-        if (el.shapeChanged()) {
+        if (needBuildPath) {
             path.beginPath();
             el.buildPath(path, el.shape);
             el.pathUpdated();


### PR DESCRIPTION
Rebuild path when an element has no path.
\- This fixes the shape may disappear after the morphing animation is finished in the SVG renderer.

See also `test/universalTransition2.html` for reproduction.

| Before | After |
| :-----: | :-----: |
| ![BA](https://user-images.githubusercontent.com/26999792/204037337-19eaa2d0-c0cd-4c30-90d6-d60c9aa1bb6c.gif) | ![AA](https://user-images.githubusercontent.com/26999792/204037643-e7608869-ed50-4df0-8d32-f993fe505a85.gif) |
| ![BB](https://user-images.githubusercontent.com/26999792/204037955-79f55c29-0702-4d1d-942b-cfc638dff192.gif) | ![AB](https://user-images.githubusercontent.com/26999792/204037946-d0234283-685a-46de-94df-85d3fca5a224.gif) |

