### PR TITLE
fix(svg): fix unexpected encoding for `style` tag

### DIFF
--- a/src/svg/core.ts
+++ b/src/svg/core.ts
@@ -70,9 +70,9 @@ export function vNodeToString(el: SVGVNode, opts?: {
     opts = opts || {};
     const S = opts.newline ? '\n' : '';
     function convertElToString(el: SVGVNode): string {
-        const {children, tag, attrs} = el;
+        const {children, tag, attrs, text} = el;
         return createElementOpen(tag, attrs)
-            + encodeHTML(el.text)
+            + (tag !== 'style' ? encodeHTML(text) : text || '')
             + (children ? `${S}${map(children, child => convertElToString(child)).join(S)}${S}` : '')
             + createElementClose(tag);
     }


### PR DESCRIPTION
#935 encodes all tags but does not exclude the `style` tag, which causes the defined CSS section not to work.