### PR TITLE
chore: release 5.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zrender",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zrender",
-      "version": "5.4.2",
+      "version": "5.4.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zrender",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "description": "A lightweight graphic library providing 2d draw for Apache ECharts",
   "keywords": [
     "canvas",

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -485,7 +485,7 @@ export function registerPainter(name: string, Ctor: PainterBaseCtor) {
 /**
  * @type {string}
  */
-export const version = '5.4.2';
+export const version = '5.4.3';
 
 
 export interface ZRenderType extends ZRender {};


### PR DESCRIPTION
When releasing ZRender 5.4.2, I forgot to run `npm run release` before `npm publish` so that the version number in `'lib'` is not correct. So we need to release a new version 5.4.3.