### PR TITLE
chore: fix deprecated npm script & add check for version and unexpected files before publishing to npm

### DIFF
--- a/build/prepublish.js
+++ b/build/prepublish.js
@@ -1,0 +1,88 @@
+const fs = require('fs-extra');
+const chalk = require('chalk');
+const ignore = require('ignore');
+const { execSync } = require('node:child_process');
+
+console.log();
+console.log(chalk.yellowBright(`⚠️ You should have run ${chalk.bold('`npm run release`')} before running this script!`));
+console.log();
+
+// check versions in key dist files
+
+console.log(chalk.yellow('🔎 Checking versions in dist files...'));
+
+const fileVersions = [
+    'package.json',
+    'package-lock.json',
+    'dist/zrender.js',
+    'dist/zrender.min.js'
+].map(filePath => ({
+    file: filePath,
+    version: require('../' + filePath).version
+}));
+
+['lib/zrender.js', 'src/zrender.ts'].forEach(filePath => {
+    const version = fs.readFileSync(filePath, 'utf-8').match(/export (?:var|const) version = '(\S+)'/)[1];
+    fileVersions.push({
+        file: filePath,
+        version: version
+    });
+});
+
+const versions = fileVersions.map(({ file, version }) => {
+    console.log(`  ∟ The version in [${chalk.blueBright(file)}] is ${chalk.cyanBright.bold(version)}`);
+    return version;
+});
+
+if (new Set(versions).size !== 1) {
+    console.log();
+    console.error(chalk.red('❌ Version does not match! Please check and rerun the release script via:'));
+    console.log();
+    console.error(chalk.yellow('     npm run release'));
+    console.log();
+    process.exit(-1);
+}
+
+console.log();
+console.log(chalk.green('✔️ Versions are all the same.'));
+console.log();
+
+console.log(chalk.yellow('🔎 Checking unexpected files that probably shouldn\'t be published...\n'));
+
+// check if there are unexpected files that not in .npmignore
+const npmignore = fs.readFileSync('.npmignore', 'utf-8');
+const npmignorePatterns = npmignore
+    .split(/\r?\n/)
+    .filter(item => item && !item.startsWith('#'));
+
+const untrackedFiles = execSync('git ls-files --others --exclude-standard', { encoding: 'utf-8' })
+    .trim()
+    .split('\n')
+    .map(escapeOctal);
+
+if (untrackedFiles.length) {
+    const maybeUnexpectedFiles = ignore().add(npmignorePatterns).filter(untrackedFiles);
+    if (maybeUnexpectedFiles.length) {
+        console.error(chalk.red(`❌ Found ${maybeUnexpectedFiles.length} file(s) that are neither tracked by git nor ignored by .npmignore! Please double-check before publishing them to npm.`));
+        maybeUnexpectedFiles.forEach(filePath => {
+            console.log('  ∟ ' + filePath);
+        });
+        console.log();
+        process.exit(-1);
+    }
+}
+
+console.log(chalk.green('✔️ No unexpected files found.'));
+console.log();
+
+function escapeOctal(str) {
+    const matches = str.match(/(\\\d{3}){3}/g);
+    if (matches) {
+        matches.forEach(match => {
+            let encoded = '';
+            match.split('\\').forEach(code => !code || (encoded += '%' + parseInt(code, 8).toString(16)));
+            str = str.replace(match, decodeURI(encoded));
+        });
+    }
+    return str;
+}

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "url": "https://github.com/ecomfe/zrender.git"
   },
   "scripts": {
-    "prepublish": "npm run release",
+    "prepare": "npm run build:lib",
     "build": "npm run build:bundle && npm run build:lib",
     "release": "node build/build.js --minify && npm run build:lib",
+    "prepublishOnly": "node build/prepublish.js",
     "prepare:nightly": "node build/prepareNightly.js",
     "prepare:nightly-next": "node build/prepareNightly.js --next",
     "build:bundle": "node build/build.js",


### PR DESCRIPTION
### Background
According to recent mistakes in publishing to npm, sometimes some files neither tracked by git nor ignored by the `.npmignore` file are unexpectedly published [1], and more often, the versions in different files are inconsistent [2][3], which is more serious than the former. Therefore, I've added a script `build/prepublish.js` that runs before really publishing distribution files to npm to reduce the possibility of this kind of mistake.

> [1] [`1.log`](https://cdn.jsdelivr.net/npm/echarts@5.4.0/1.log) was published to npm in Apache ECharts v5.4.0
> [2] Published v5.4.2 but [the version in `lib/zrender.js`](https://cdn.jsdelivr.net/npm/zrender@5.4.2/lib/zrender.js) is still `5.4.1`
> [3] Published v5.3.1 but both [the version in `lib/zrender.js`](https://cdn.jsdelivr.net/npm/zrender@5.4.2/lib/zrender.js) and [the version in `src/zrender.ts`](https://github.com/ecomfe/zrender/blob/5.3.1/src/zrender.ts#L475) are still `5.3.0`

### Changes

**1. Replace the deprecated `prepublish` hook in favor of `prepare` & `prepublishOnly`.**

**2.  Check the consistency of versions in different key distribution files.**

>    \- **_package.json_**
>    \- **_package-lock.json_**
>    \- **_dist/zrender.js_**
>    \- **_dist/zrender.min.js_**
>    \- **_lib/zrender.js_**
>    \- **_src/zrender.ts_**

This will output the version in each file and the file path to help you confirm if they are all expected.
If the version in any file doesn't match the others, an error will be shown, and it will give the corresponding steps to fix it.

<img src="https://user-images.githubusercontent.com/26999792/224509422-f50453f7-1fbb-458a-876f-624d1e3b473c.png" width="600">

**3. Check if there are unexpected files that probably shouldn't be published.**

   This will list all untracked files by git and check if they have been ignored by the `.npmignore` file.
   If not, an error will be shown and output all unexpected files for double-check.

![image](https://user-images.githubusercontent.com/26999792/224509373-3837d50d-c672-4370-9c1f-6bcb3ed99759.png)
