### PR TITLE
fix(svg): duplicate id for background rect with multiple charts

### DIFF
--- a/src/canvas/Layer.ts
+++ b/src/canvas/Layer.ts
@@ -311,7 +311,7 @@ export default class Layer extends Eventful {
              * rect if and only if it's not painted this frame and was
              * previously painted on the canvas.
              */
-            const shouldPaint = el.shouldBePainted(viewWidth, viewHeight, true, true);
+            const shouldPaint = el && el.shouldBePainted(viewWidth, viewHeight, true, true);
             if (el && (!shouldPaint || !el.__zr) && el.__isRendered) {
                 // el was removed
                 const prevRect = el.getPrevPaintRect();

--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -143,7 +143,7 @@ class SVGPainter implements PainterBase {
 
         const children: SVGVNode[] = [];
 
-        const bgVNode = this._bgVNode = createBackgroundVNode(this._id, width, height, this._backgroundColor, scope);
+        const bgVNode = this._bgVNode = createBackgroundVNode(width, height, this._backgroundColor, scope);
         bgVNode && children.push(bgVNode);
 
         // Ignore the root g if wan't the output to be more tight.
@@ -360,7 +360,6 @@ function createMethodNotSupport(method: string): any {
 }
 
 function createBackgroundVNode(
-    zrId: string,
     width: number,
     height: number,
     backgroundColor: SVGPainterBackgroundColor,
@@ -375,8 +374,7 @@ function createBackgroundVNode(
                 width,
                 height,
                 x: '0',
-                y: '0',
-                id: zrId + '-bg'
+                y: '0'
             }
         );
         if (isGradient(backgroundColor)) {

--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -143,7 +143,7 @@ class SVGPainter implements PainterBase {
 
         const children: SVGVNode[] = [];
 
-        const bgVNode = this._bgVNode = createBackgroundVNode(width, height, this._backgroundColor, scope);
+        const bgVNode = this._bgVNode = createBackgroundVNode(this._id, width, height, this._backgroundColor, scope);
         bgVNode && children.push(bgVNode);
 
         // Ignore the root g if wan't the output to be more tight.
@@ -360,6 +360,7 @@ function createMethodNotSupport(method: string): any {
 }
 
 function createBackgroundVNode(
+    zrId: string,
     width: number,
     height: number,
     backgroundColor: SVGPainterBackgroundColor,
@@ -375,7 +376,7 @@ function createBackgroundVNode(
                 height,
                 x: '0',
                 y: '0',
-                id: '0'
+                id: zrId + '-bg'
             }
         );
         if (isGradient(backgroundColor)) {

--- a/test/svg-backgroundColor.html
+++ b/test/svg-backgroundColor.html
@@ -16,9 +16,6 @@
 </head>
 <body>
     <div id="main" style="width:100vw;height:100vh;"></div>
-
-    <h2>This should not have a rect with the same id as the above instance.</h2>
-    <div id="main2" style="width:100vw;height:100vh;"></div>
     <div class="opt-bar">
         <button onclick="updateBg()">Change Background</button>
         <select id="repeat">
@@ -45,11 +42,6 @@
         }
     });
     zr.add(txt);
-
-    var zr2 = zrender.init(document.getElementById('main2'), {
-        renderer: 'svg'
-    });
-    zr2.add(txt);
 
     var linearGradient = new zrender.LinearGradient();
     linearGradient.addColorStop(0, '#a598e1');
@@ -104,7 +96,6 @@
             bg = text = 'none';
         }
         zr.setBackgroundColor(bg);
-        zr2.setBackgroundColor(bg);
         txt.setStyle({ text: 'SVG BackgroundColor: ' + text });
         i++;
     }

--- a/test/svg-backgroundColor.html
+++ b/test/svg-backgroundColor.html
@@ -16,6 +16,9 @@
 </head>
 <body>
     <div id="main" style="width:100vw;height:100vh;"></div>
+
+    <h2>This should not have a rect with the same id as the above instance.</h2>
+    <div id="main2" style="width:100vw;height:100vh;"></div>
     <div class="opt-bar">
         <button onclick="updateBg()">Change Background</button>
         <select id="repeat">
@@ -42,7 +45,12 @@
         }
     });
     zr.add(txt);
-    
+
+    var zr2 = zrender.init(document.getElementById('main2'), {
+        renderer: 'svg'
+    });
+    zr2.add(txt);
+
     var linearGradient = new zrender.LinearGradient();
     linearGradient.addColorStop(0, '#a598e1');
     linearGradient.addColorStop(1, '#14c4ba');
@@ -95,8 +103,8 @@
         else {
             bg = text = 'none';
         }
-        console.log(text);
         zr.setBackgroundColor(bg);
+        zr2.setBackgroundColor(bg);
         txt.setStyle({ text: 'SVG BackgroundColor: ' + text });
         i++;
     }


### PR DESCRIPTION
Fix apache/echarts#18194 where the background rect of svg charts are all having the same `id="0"`.