### PR TITLE
fix(transform): fix `invTransform` may not be reset when updating transform

### DIFF
--- a/src/core/Transformable.ts
+++ b/src/core/Transformable.ts
@@ -108,7 +108,11 @@ class Transformable {
 
         let m = this.transform;
         if (!(needLocalTransform || parentTransform)) {
-            m && mIdentity(m);
+            if (m) {
+                mIdentity(m);
+                // reset invTransform
+                this.invTransform = null;
+            }
             return;
         }
 


### PR DESCRIPTION
Resolves apache/echarts#18412. See apache/echarts#18625 for the test case.

When checking the hovering target, the [`Transformable#transformCoordToLocal`](https://github.com/ecomfe/zrender/blob/5.4.3/src/core/Transformable.ts#L257-L264) function will be used in the [`Displayable#rectContain`](https://github.com/ecomfe/zrender/blob/5.4.3/src/graphic/Displayable.ts#L264-L268) function.

But in the [`Transformable#updateTransform`](https://github.com/ecomfe/zrender/blob/5.4.3/src/core/Transformable.ts#L105-L113) function, the `invTransform` is not reset when the `transform` is set to the identity matrix, which may result in a wrong local coordinate.
