### PR TITLE
feat: export internal Painter

### DIFF
--- a/src/all.ts
+++ b/src/all.ts
@@ -6,3 +6,4 @@ import CanvasPainter from './canvas/Painter';
 import SVGPainter from './svg/Painter';
 registerPainter('canvas', CanvasPainter);
 registerPainter('svg', SVGPainter);
+export { CanvasPainter, SVGPainter };


### PR DESCRIPTION
when I use vite, the internal call to the 'registerPainter' method will be treeshaking.
