### PR TITLE
fix: add `lib/all.js` to sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "sideEffects": [
     "lib/canvas/canvas.js",
-    "lib/svg/svg.js"
+    "lib/svg/svg.js",
+    "lib/all.js"
   ],
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.2",


### PR DESCRIPTION
When I use vite, the internal call to the 'registerPainter' method will be treeshaking.