### PR TITLE
fix(svg): fix assigning style attribute does not work when CSP is enforced

### DIFF
--- a/src/svg/patch.ts
+++ b/src/svg/patch.ts
@@ -122,7 +122,7 @@ function removeVnodes(parentElm: Node, vnodes: SVGVNode[], startIdx: number, end
 
 export function updateAttrs(oldVnode: SVGVNode, vnode: SVGVNode): void {
     let key: string;
-    const elm = vnode.elm as Element;
+    const elm = vnode.elm as SVGElement;
     const oldAttrs = oldVnode && oldVnode.attrs || {};
     const attrs = vnode.attrs || {};
 
@@ -143,7 +143,10 @@ export function updateAttrs(oldVnode: SVGVNode, vnode: SVGVNode): void {
                 elm.removeAttribute(key);
             }
             else {
-                if (key.charCodeAt(0) !== xChar) {
+                if (key === 'style') {
+                    elm.style.cssText = cur as string
+                }
+                else if (key.charCodeAt(0) !== xChar) {
                     elm.setAttribute(key, cur as any);
                 }
                 // TODO


### PR DESCRIPTION
Fixes https://github.com/apache/echarts/issues/16610

## Overview

This pull request addresses a specific limitation concerning [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP). When CSP is enabled, direct assignments to an element's style property using a string are disallowed. However it is possible to use `element.style.cssText = ...` instead.

## Reproduction

Create and open an HTML file with the following content:
```
<!DOCTYPE html>
<html>
  <head>
    <meta
      http-equiv="Content-Security-Policy"
      content="script-src 'nonce-my-nonce'; style-src 'nonce-my-nonce'"
    />
    <style nonce="my-nonce">
      #main {
        width: 100vw;
        height: 100vh;
      }
    </style>
  </head>
  <body>
    <div id="main"></div>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/zrender/5.4.4/zrender.min.js" nonce="my-nonce"></script>
    <script nonce="my-nonce">
      const zr = zrender.init(document.getElementById("main"), {
        renderer: "svg",
      });

      var text = new zrender.Text({
        style: {
          text: "this text should be 64px and bold",
          fill: "red",
          font: "bold 64px sans-serif",
          textAlign: "center",
        },
        x: 100,
        y: 100,
      });

      zr.add(text);
    </script>
  </body>
</html>
```

In the console you should see the following error:
<img width="873" alt="Screen Shot 2023-09-18 at 4 18 47 PM" src="https://github.com/ecomfe/zrender/assets/14301985/2a6d5fc6-4ba8-43ba-b6a6-e1b13dcafcb3">

