### PR TITLE
fix: avoid errors when executing unfinished operations after dispose

### DIFF
--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -81,7 +81,7 @@ class ZRender {
 
     private _needsRefresh = true
     private _needsRefreshHover = true
-    private _disposed = false;
+    private _disposed: boolean;
     /**
      * If theme is dark mode. It will determine the color strategy for labels.
      */
@@ -154,7 +154,7 @@ class ZRender {
      * 添加元素
      */
     add(el: Element) {
-        if (!el || this._disposed) {
+        if (this._disposed || !el) {
             return;
         }
         this.storage.addRoot(el);
@@ -166,7 +166,7 @@ class ZRender {
      * 删除元素
      */
     remove(el: Element) {
-        if (!el || this._disposed) {
+        if (this._disposed || !el) {
             return;
         }
         this.storage.delRoot(el);
@@ -178,7 +178,7 @@ class ZRender {
      * Change configuration of layer
     */
     configLayer(zLevel: number, config: LayerConfig) {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         if (this.painter.configLayer) {
@@ -191,7 +191,7 @@ class ZRender {
      * Set background color
      */
     setBackgroundColor(backgroundColor: string | GradientObject | PatternObject) {
-        if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         if (this.painter.setBackgroundColor) {
@@ -221,7 +221,7 @@ class ZRender {
      * Repaint the canvas immediately
      */
     refreshImmediately(fromInside?: boolean) {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         // const start = new Date();
@@ -243,7 +243,7 @@ class ZRender {
      * Mark and repaint the canvas in the next frame of browser
      */
     refresh() {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         this._needsRefresh = true;
@@ -255,7 +255,7 @@ class ZRender {
      * Perform all refresh
      */
     flush() {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         this._flush(false);
@@ -303,7 +303,7 @@ class ZRender {
      * Wake up animation loop. But not render.
      */
     wakeUp() {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         this.animation.start();
@@ -322,7 +322,7 @@ class ZRender {
      * Refresh hover immediately
      */
     refreshHoverImmediately() {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         this._needsRefreshHover = false;
@@ -339,7 +339,7 @@ class ZRender {
         width?: number| string
         height?: number | string
     }) {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         opts = opts || {};
@@ -351,7 +351,7 @@ class ZRender {
      * Stop and clear all animation immediately
      */
     clearAnimation() {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         this.animation.clear();
@@ -360,8 +360,8 @@ class ZRender {
     /**
      * Get container width
      */
-    getWidth(): number {
-       if(this._disposed) {
+    getWidth(): number | undefined {
+        if (this._disposed) {
             return;
         }
         return this.painter.getWidth();
@@ -370,8 +370,8 @@ class ZRender {
     /**
      * Get container height
      */
-    getHeight(): number {
-       if(this._disposed) {
+    getHeight(): number | undefined {
+        if (this._disposed) {
             return;
         }
         return this.painter.getHeight();
@@ -382,6 +382,9 @@ class ZRender {
      * @param cursorStyle='default' 例如 crosshair
      */
     setCursorStyle(cursorStyle: string) {
+        if (this._disposed) {
+            return;
+        }
         this.handler.setCursorStyle(cursorStyle);
     }
 
@@ -394,7 +397,10 @@ class ZRender {
     findHover(x: number, y: number): {
         target: Displayable
         topTarget: Displayable
-    } {
+    } | undefined {
+        if (this._disposed) {
+            return;
+        }
         return this.handler.findHover(x, y);
     }
 
@@ -403,7 +409,9 @@ class ZRender {
     on<Ctx>(eventName: string, eventHandler: WithThisType<EventCallback<any[]>, unknown extends Ctx ? ZRenderType : Ctx>, context?: Ctx): this
     // eslint-disable-next-line max-len
     on<Ctx>(eventName: string, eventHandler: (...args: any) => any, context?: Ctx): this {
-        this.handler.on(eventName, eventHandler, context);
+        if (!this._disposed) {
+            this.handler.on(eventName, eventHandler, context);
+        }
         return this;
     }
 
@@ -414,7 +422,7 @@ class ZRender {
      */
     // eslint-disable-next-line max-len
     off(eventName?: string, eventHandler?: EventCallback) {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         this.handler.off(eventName, eventHandler);
@@ -427,7 +435,7 @@ class ZRender {
      * @param event Event object
      */
     trigger(eventName: string, event?: unknown) {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         this.handler.trigger(eventName, event);
@@ -438,7 +446,7 @@ class ZRender {
      * Clear all objects and the canvas.
      */
     clear() {
-       if(this._disposed) {
+        if (this._disposed) {
             return;
         }
         const roots = this.storage.getRoots();
@@ -455,6 +463,10 @@ class ZRender {
      * Dispose self.
      */
     dispose() {
+        if (this._disposed) {
+            return;
+        }
+
         this.animation.stop();
 
         this.clear();

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -81,7 +81,7 @@ class ZRender {
 
     private _needsRefresh = true
     private _needsRefreshHover = true
-
+    private _disposed = false;
     /**
      * If theme is dark mode. It will determine the color strategy for labels.
      */
@@ -154,7 +154,7 @@ class ZRender {
      * 添加元素
      */
     add(el: Element) {
-        if (!el) {
+        if (!el || this._disposed) {
             return;
         }
         this.storage.addRoot(el);
@@ -166,7 +166,7 @@ class ZRender {
      * 删除元素
      */
     remove(el: Element) {
-        if (!el) {
+        if (!el || this._disposed) {
             return;
         }
         this.storage.delRoot(el);
@@ -178,6 +178,9 @@ class ZRender {
      * Change configuration of layer
     */
     configLayer(zLevel: number, config: LayerConfig) {
+       if(this._disposed) {
+            return;
+        }
         if (this.painter.configLayer) {
             this.painter.configLayer(zLevel, config);
         }
@@ -188,6 +191,9 @@ class ZRender {
      * Set background color
      */
     setBackgroundColor(backgroundColor: string | GradientObject | PatternObject) {
+        if(this._disposed) {
+            return;
+        }
         if (this.painter.setBackgroundColor) {
             this.painter.setBackgroundColor(backgroundColor);
         }
@@ -215,6 +221,9 @@ class ZRender {
      * Repaint the canvas immediately
      */
     refreshImmediately(fromInside?: boolean) {
+       if(this._disposed) {
+            return;
+        }
         // const start = new Date();
         if (!fromInside) {
             // Update animation if refreshImmediately is invoked from outside.
@@ -234,6 +243,9 @@ class ZRender {
      * Mark and repaint the canvas in the next frame of browser
      */
     refresh() {
+       if(this._disposed) {
+            return;
+        }
         this._needsRefresh = true;
         // Active the animation again.
         this.animation.start();
@@ -243,6 +255,9 @@ class ZRender {
      * Perform all refresh
      */
     flush() {
+       if(this._disposed) {
+            return;
+        }
         this._flush(false);
     }
 
@@ -288,6 +303,9 @@ class ZRender {
      * Wake up animation loop. But not render.
      */
     wakeUp() {
+       if(this._disposed) {
+            return;
+        }
         this.animation.start();
         // Reset the frame count.
         this._stillFrameAccum = 0;
@@ -304,6 +322,9 @@ class ZRender {
      * Refresh hover immediately
      */
     refreshHoverImmediately() {
+       if(this._disposed) {
+            return;
+        }
         this._needsRefreshHover = false;
         if (this.painter.refreshHover && this.painter.getType() === 'canvas') {
             this.painter.refreshHover();
@@ -318,6 +339,9 @@ class ZRender {
         width?: number| string
         height?: number | string
     }) {
+       if(this._disposed) {
+            return;
+        }
         opts = opts || {};
         this.painter.resize(opts.width, opts.height);
         this.handler.resize();
@@ -327,6 +351,9 @@ class ZRender {
      * Stop and clear all animation immediately
      */
     clearAnimation() {
+       if(this._disposed) {
+            return;
+        }
         this.animation.clear();
     }
 
@@ -334,6 +361,9 @@ class ZRender {
      * Get container width
      */
     getWidth(): number {
+       if(this._disposed) {
+            return;
+        }
         return this.painter.getWidth();
     }
 
@@ -341,6 +371,9 @@ class ZRender {
      * Get container height
      */
     getHeight(): number {
+       if(this._disposed) {
+            return;
+        }
         return this.painter.getHeight();
     }
 
@@ -381,6 +414,9 @@ class ZRender {
      */
     // eslint-disable-next-line max-len
     off(eventName?: string, eventHandler?: EventCallback) {
+       if(this._disposed) {
+            return;
+        }
         this.handler.off(eventName, eventHandler);
     }
 
@@ -391,6 +427,9 @@ class ZRender {
      * @param event Event object
      */
     trigger(eventName: string, event?: unknown) {
+       if(this._disposed) {
+            return;
+        }
         this.handler.trigger(eventName, event);
     }
 
@@ -399,6 +438,9 @@ class ZRender {
      * Clear all objects and the canvas.
      */
     clear() {
+       if(this._disposed) {
+            return;
+        }
         const roots = this.storage.getRoots();
         for (let i = 0; i < roots.length; i++) {
             if (roots[i] instanceof Group) {
@@ -424,6 +466,8 @@ class ZRender {
         this.storage =
         this.painter =
         this.handler = null;
+
+        this._disposed = true;
 
         delInstance(this.id);
     }

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -123,7 +123,7 @@ class ZRender {
         this.storage = storage;
         this.painter = painter;
 
-        const handerProxy = (!env.node && !env.worker && !ssrMode)
+        const handlerProxy = (!env.node && !env.worker && !ssrMode)
             ? new HandlerProxy(painter.getViewportRoot(), painter.root)
             : null;
 
@@ -137,7 +137,7 @@ class ZRender {
             pointerSize = zrUtil.retrieve2(opts.pointerSize, defaultPointerSize);
         }
 
-        this.handler = new Handler(storage, painter, handerProxy, painter.root, pointerSize);
+        this.handler = new Handler(storage, painter, handlerProxy, painter.root, pointerSize);
 
         this.animation = new Animation({
             stage: {
@@ -284,7 +284,7 @@ class ZRender {
         }
         else if (this._sleepAfterStill > 0) {
             this._stillFrameAccum++;
-            // Stop the animiation after still for 10 frames.
+            // Stop the animation after still for 10 frames.
             if (this._stillFrameAccum > this._sleepAfterStill) {
                 this.animation.stop();
             }


### PR DESCRIPTION

A chart is performing certain operations. After the operation, it will be refreshed and calling flush. At this time, the instance has been disposed, an error will appear. such this [issue](https://github.com/ecomfe/zrender/issues/904) and in react native echart [issue](https://github.com/wuba/react-native-echarts/issues/92)