### PR TITLE
fix(canvas): fix potential NPE in canvas pattern dirty callback handler

### DIFF
--- a/src/canvas/Layer.ts
+++ b/src/canvas/Layer.ts
@@ -89,8 +89,6 @@ export default class Layer extends Eventful {
 
     private _paintRects: BoundingRect[]
 
-    __painter: CanvasPainter
-
     __dirty = true
     __firstTimePaint = true
 
@@ -449,9 +447,8 @@ export default class Layer extends Eventful {
                     clearColorGradientOrPattern = createCanvasPattern(
                         ctx, clearColor, {
                             dirty() {
-                                // TODO
                                 self.setUnpainted();
-                                self.__painter.refresh();
+                                self.painter.refresh();
                             }
                         }
                     );

--- a/src/canvas/Painter.ts
+++ b/src/canvas/Painter.ts
@@ -597,7 +597,7 @@ export default class CanvasPainter implements PainterBase {
 
         layersMap[zlevel] = layer;
 
-        // Vitual layer will not directly show on the screen.
+        // Virtual layer will not directly show on the screen.
         // (It can be a WebGL layer and assigned to a ZRImage element)
         // But it still under management of zrender.
         if (!layer.virtual) {
@@ -623,7 +623,7 @@ export default class CanvasPainter implements PainterBase {
             }
         }
 
-        layer.__painter = this;
+        layer.painter || (layer.painter = this);
     }
 
     // Iterate each layer


### PR DESCRIPTION
As we discussed before, some extension libraries may create their own `Layer` for customization via [`Painter#insertLayer`](https://github.com/ecomfe/zrender/blob/5.4.4/src/canvas/Painter.ts#L562-L627) and probably won't inject the `painter` property into the canvas painter like [`echarts-gl`](https://github.com/search?q=repo%3Aecomfe%2Fecharts-gl%20insertLayer&type=code) and [`echarts-for-weixin`](https://github.com/ecomfe/echarts-for-weixin) [1], this results in [a potential NPE in the canvas pattern dirty callback handler](https://github.com/ecomfe/zrender/blob/5.4.4/src/canvas/Layer.ts#L454).

So it's better to remove the redundant `__painter` from `Layer` to reuse the existing `painter` property and inject `painter` in `Painter#insertLayer` when it doesn't exist.

[1] Error threw in `echarts-for-weixin` when loading the pattern

![image](https://github.com/ecomfe/zrender/assets/26999792/ce56f99e-0132-4095-9b69-8ac156a86ece)
