### PR TITLE
fix(type): make the last two parameters `ellipsis` & `options` of the function `truncateText` optional

### DIFF
--- a/src/graphic/helper/parseText.ts
+++ b/src/graphic/helper/parseText.ts
@@ -41,8 +41,8 @@ export function truncateText(
     text: string,
     containerWidth: number,
     font: string,
-    ellipsis: string,
-    options: InnerTruncateOption
+    ellipsis?: string,
+    options?: InnerTruncateOption
 ): string {
     if (!containerWidth) {
         return '';
@@ -63,8 +63,8 @@ export function truncateText(
 function prepareTruncateOptions(
     containerWidth: number,
     font: string,
-    ellipsis: string,
-    options: InnerTruncateOption
+    ellipsis?: string,
+    options?: InnerTruncateOption
 ): InnerPreparedTruncateOption {
     options = options || {};
     let preparedOpts = extend({}, options) as InnerPreparedTruncateOption;


### PR DESCRIPTION
This PR brings some type tweaks for the parameters of the function `truncateText`.

Resolves apache/echarts#19447