### PR TITLE
fix(svg): skip to set SSR attributes with `undefined` values

### DIFF
--- a/src/svg/graphic.ts
+++ b/src/svg/graphic.ts
@@ -79,8 +79,7 @@ function setMetaData(attrs: SVGVNodeAttrs, el: Path | TSpan | ZRImage) {
     const metaData = getElementSSRData(el);
     if (metaData) {
         metaData.each((val, key) => {
-            attrs[(META_DATA_PREFIX + key).toLowerCase()]
-                = val + '';
+            val != null && (attrs[(META_DATA_PREFIX + key).toLowerCase()] = val + '');
         });
         if (el.isSilent()) {
             attrs[META_DATA_PREFIX + 'silent'] = 'true';

--- a/src/zrender.ts
+++ b/src/zrender.ts
@@ -541,9 +541,7 @@ export function registerPainter(name: string, Ctor: PainterBaseCtor) {
 export type ElementSSRData = zrUtil.HashMap<unknown>;
 export type ElementSSRDataGetter<T> = (el: Element) => zrUtil.HashMap<T>;
 
-let ssrDataGetter = function (el: Element): ElementSSRData {
-    return null;
-}
+let ssrDataGetter: ElementSSRDataGetter<unknown>;
 
 export function getElementSSRData(el: Element): ElementSSRData {
     if (typeof ssrDataGetter === 'function') {


### PR DESCRIPTION
See also apache/echarts#19461