### PR TITLE
Fix package.json exports

### DIFF
--- a/package.README.md
+++ b/package.README.md
@@ -1,0 +1,9 @@
+# NOTICE about package.json
+
+Only `zrender.js` are officially exported to users.
+
+The other entries listed in the `"exports"` field of `package.json` make the internal files visible, but they are legacy usages, not recommended but not forbidden (for the sake of keeping backward compatible). These entries are made from the search in github about which internal files are imported.
+
+Since `v5.5.0`, `"type": "module"` and `"exports: {...}"` are added to `package.json`. When upgrading to `v5.5.0+`, if you meet some problems about "can not find/resolve xxx" when importing some internal files, it probably because of the issue "file extension not fully specified". Please try to make the file extension fully specified (that is, `import 'xxx/xxx/xxx.js'` rather than `import 'xxx/xxx/xxx'`), or change the config of you bundler tools to support auto adding file extensions.
+
+See more details about the `"exports"` field of `package.json` and why it is written like that in https://github.com/apache/echarts/pull/19513 .

--- a/package.json
+++ b/package.json
@@ -67,9 +67,23 @@
       "require": "./dist/zrender.js",
       "import": "./index.js"
     },
-    "./*.js": "./*.js",
-    "./*.ts": "./*.ts",
-    "./*.json": "./*.json",
-    "./*": "./*.js"
+    "./lib/canvas/canvas": "./lib/canvas/canvas.js",
+    "./lib/svg/svg": "./lib/svg/svg.js",
+    "./lib/vml/vml": "./lib/vml/vml.js",
+    "./lib/canvas/Painter": "./lib/canvas/Painter.js",
+    "./lib/svg/Painter": "./lib/svg/Painter.js",
+    "./lib/svg/patch": "./lib/svg/patch.js",
+    "./lib/Storage": "./lib/Storage.js",
+    "./lib/core/util": "./lib/core/util.js",
+    "./lib/core/env": "./lib/core/env.js",
+    "./lib/core/Transformable": "./lib/core/Transformable.js",
+    "./lib/core/BoundingRect": "./lib/core/BoundingRect.js",
+    "./lib/core/vector": "./lib/core/vector.js",
+    "./lib/core/bbox": "./lib/core/bbox.js",
+    "./lib/contain/polygon": "./lib/contain/polygon.js",
+    "./lib/tool/color": "./lib/tool/color.js",
+    "./lib/graphic/LinearGradient": "./lib/graphic/LinearGradient.js",
+    "./lib/graphic/RadialGradient": "./lib/graphic/RadialGradient.js",
+    "./*": "./*"
   }
 }


### PR DESCRIPTION
Fix: 
1. fix that some old version bundler (like rollup) do not recognize wildcard that not at the end of the patter string (e.g. "exports: {"./*.js": "xxx"}"). 
2. Add readme to package.json.

See details in #1051