### PR TITLE
chore(workflow): update actions/checkout + actions/setup-node to v4

### DIFF
--- a/.github/workflows/nightly-next.yaml
+++ b/.github/workflows/nightly-next.yaml
@@ -17,12 +17,12 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: next
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,9 +17,9 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           registry-url: https://registry.npmjs.org/
       - name: Setup and publish nightly


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* update [`actions/setup-node`](https://github.com/actions/setup-node) to v4

Still using the older versions of these actions will generate several warnings in CI runs, for example in https://github.com/ecomfe/zrender/actions/runs/7692866561:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings.