### PR TITLE
fix: fix memory leak due to invalid image src

### DIFF
--- a/src/graphic/helper/image.ts
+++ b/src/graphic/helper/image.ts
@@ -13,6 +13,7 @@ type PendingWrap = {
 
 type CachedImageObj = {
     image: ImageLike
+    loading: boolean
     pending: PendingWrap[]
 }
 
@@ -62,7 +63,7 @@ export function createOrUpdateImage<T>(
 
         if (cachedImgObj) {
             image = cachedImgObj.image;
-            !isImageReady(image) && cachedImgObj.pending.push(pendingWrap);
+            cachedImgObj.loading && cachedImgObj.pending.push(pendingWrap);
         }
         else {
             image = platformApi.loadImage(
@@ -74,6 +75,7 @@ export function createOrUpdateImage<T>(
                 newImageOrSrc,
                 (image as any).__cachedImgObj = {
                     image: image,
+                    loading: true,
                     pending: [pendingWrap]
                 }
             );
@@ -89,6 +91,7 @@ export function createOrUpdateImage<T>(
 
 function imageOnLoad(this: any) {
     const cachedImgObj = this.__cachedImgObj;
+    cachedImgObj.loading = false;
     this.onload = this.onerror = this.__cachedImgObj = null;
 
     for (let i = 0; i < cachedImgObj.pending.length; i++) {


### PR DESCRIPTION
从`isImageReady`修改为`loading`标记来判断图片是否已经完成加载，以此决定是否要添加到 `pending` 队列，解决无效图片路径可导致 `globalImageCache` 内存泄漏的问题。
具体请查看 #1072