### PR TITLE
fix(platform): fix `measureText` can't recognize decimal font size

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -75,7 +75,7 @@ export const platformApi: Platform = {
                 text = text || '';
                 font = font || DEFAULT_FONT;
                 // Use font size if there is no other method can be used.
-                const res = /(\d+)px/.exec(font);
+                const res = /((\d+)?\.?\d*)px/.exec(font);
                 const fontSize = res && +res[1] || DEFAULT_FONT_SIZE;
                 let width = 0;
                 if (font.indexOf('mono') >= 0) {   // is monospace

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -75,7 +75,7 @@ export const platformApi: Platform = {
                 text = text || '';
                 font = font || DEFAULT_FONT;
                 // Use font size if there is no other method can be used.
-                const res = /((\d+)?\.?\d*)px/.exec(font);
+                const res = /((?:\d+)?\.?\d*)px/.exec(font);
                 const fontSize = res && +res[1] || DEFAULT_FONT_SIZE;
                 let width = 0;
                 if (font.indexOf('mono') >= 0) {   // is monospace


### PR DESCRIPTION
I am using echarts in a react native environment.
Which uses rem adaptation, so a similar code appears
fontSize: rem(12) => fontSize: 11.5
I found a problem.When fontSzie is set to decimal it causes some rendering exceptions.
After troubleshooting I found out that it is an issue with a regularity in measureText in zrender. This regular expression was causing abnormal behavior when parsing decimals.
