### PR TITLE
Update BoundingRect intersection check

### DIFF
--- a/src/core/BoundingRect.ts
+++ b/src/core/BoundingRect.ts
@@ -109,6 +109,10 @@ class BoundingRect {
         const by0 = b.y;
         const by1 = b.y + b.height;
 
+        if ((a.width <= 0 && a.height <= 0) || (b.width <= 0 && b.height <= 0)) {
+            return false;
+        }
+
         let overlap = !(ax1 < bx0 || bx1 < ax0 || ay1 < by0 || by1 < ay0);
         if (mtv) {
             let dMin = Infinity;


### PR DESCRIPTION
- For full context, see the corresponding PR in the ECharts repository: https://github.com/apache/echarts/pull/19982

---
**Bug Fix:** This PR is intended to fix the `hideOverlap` functionality in ECharts by preventing empty labels (`""`) from being considered as candidates for the overlap checking.
- An empty label is also a bounding rect with width and height <= 0