### PR TITLE
chore: exclude some unused dirs and files when publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 /doc
 /test
 /benchmark
+/build
+/tsconfig.json
 .github
 .vscode
 
@@ -8,3 +10,6 @@ npm-debug.log
 .DS_Store
 Thumbs.db
 Desktop.ini
+
+.eslintignore
+.eslintrc.yaml


### PR DESCRIPTION
Similar to apache/echarts#19695 but the `src` folder is reserved since ECharts will import the source code from this folder.