### PR TITLE
chore: still publish `build` folder to npm as echarts needs it

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 /doc
 /test
 /benchmark
-/build
 /tsconfig.json
 .github
 .vscode


### PR DESCRIPTION
#1085 excluded the whole `build` folder from npm package, which is imported by echarts and causes the echarts package to fail to publish. So this PR is to add this folder back.

[1] https://github.com/apache/echarts/actions/runs/9971316886/job/27552144963#step:4:59
[2] https://github.com/apache/echarts/blob/master/build/pre-publish.js#L42
 