### PR TITLE
fix(text): not need fixed bounding box when contentWidth min than style.width

### DIFF
--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -554,6 +554,7 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
         const hasShadow = style.textShadowBlur > 0;
 
         const fixedBoundingRect = style.width != null
+            && text !== textLines[0]
             && (style.overflow === 'truncate' || style.overflow === 'break' || style.overflow === 'breakAll');
         const calculatedLineHeight = contentBlock.calculatedLineHeight;
 


### PR DESCRIPTION
When `overflow` is set and `style.width` is not empty, a fixed boundingBox is used, where the x value of the boundingBox is adjusted according to style.width.

https://github.com/ecomfe/zrender/blob/247e11966657fb0fd3d92533e15e8b655bff3327/src/graphic/Text.ts#L604-L614

However, when the width of the text is smaller than the set `style.width`, the boundingBox will be positioned to the left, as shown in the following figure.

![image](https://github.com/user-attachments/assets/1e00e82e-cfe3-4aca-bb09-e5053ec961cf)


https://github.com/user-attachments/assets/b4de2455-b083-4bdf-9b8b-ff8b5c9bb0d0



fix https://github.com/apache/echarts/issues/18306