### PR TITLE
fix(path): using appendData instead of setData for path

### DIFF
--- a/src/core/PathProxy.ts
+++ b/src/core/PathProxy.ts
@@ -389,11 +389,8 @@ export default class PathProxy {
         for (let i = 0; i < len; i++) {
             appendSize += path[i].len();
         }
-        if (hasTypedArray && (this.data instanceof Float32Array)) {
+        if (hasTypedArray && (this.data instanceof Float32Array || !this.data)) {
             this.data = new Float32Array(offset + appendSize);
-        }
-        else if (this.data == null) {
-            this.data = [];
         }
         for (let i = 0; i < len; i++) {
             const appendPathData = path[i].data;

--- a/src/core/PathProxy.ts
+++ b/src/core/PathProxy.ts
@@ -392,6 +392,9 @@ export default class PathProxy {
         if (hasTypedArray && (this.data instanceof Float32Array)) {
             this.data = new Float32Array(offset + appendSize);
         }
+        else if (this.data == null) {
+            this.data = [];
+        }
         for (let i = 0; i < len; i++) {
             const appendPathData = path[i].data;
             for (let k = 0; k < appendPathData.length; k++) {

--- a/src/tool/path.ts
+++ b/src/tool/path.ts
@@ -389,7 +389,7 @@ function createPathOptions(str: string, opts: SVGPathOption): InnerSVGPathOption
     const innerOpts: InnerSVGPathOption = extend({}, opts);
     innerOpts.buildPath = function (path: PathProxy | CanvasRenderingContext2D) {
         if (isPathProxy(path)) {
-            path.setData(pathProxy.data);
+            path.appendPath(pathProxy);
             // Svg and vml renderer don't have context
             const ctx = path.getContext();
             if (ctx) {


### PR DESCRIPTION
When providing the ability to support `compoundPath` for custom series in Apache ECharts, I found that only the last path data is rendered in a compundPath. This is cause by calling `setData` instead of `appendData` in Path.