### PR TITLE
Relax tslib requirement specifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tslib": "2.3.0"
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@microsoft/api-extractor": "^7.7.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "module": "index.js",
   "main": "dist/zrender.js",
   "dependencies": {
-    "tslib": "2.3.0"
+    "tslib": "^2.3.0"
   },
   "sideEffects": [
     "lib/canvas/canvas.js",


### PR DESCRIPTION
Along with https://github.com/apache/echarts/pull/20485, this allows users to select their own version of tslib (without having to resort to resolutions to force it).