### PR TITLE
feat(polyline): support drawMode: lines

### DIFF
--- a/src/graphic/helper/poly.ts
+++ b/src/graphic/helper/poly.ts
@@ -8,36 +8,90 @@ export function buildPath(
     shape: {
         points: VectorArray[],
         smooth?: number
-        smoothConstraint?: VectorArray[]
+        smoothConstraint?: VectorArray[],
+        drawMode?: 'lineStrip' | 'lines'
     },
     closePath: boolean
 ) {
     const smooth = shape.smooth;
+    const drawMode = shape.drawMode || 'lineStrip';
     let points = shape.points;
     if (points && points.length >= 2) {
         if (smooth) {
-            const controlPoints = smoothBezier(
-                points, smooth, closePath, shape.smoothConstraint
-            );
-
-            ctx.moveTo(points[0][0], points[0][1]);
-            const len = points.length;
-            for (let i = 0; i < (closePath ? len : len - 1); i++) {
-                const cp1 = controlPoints[i * 2];
-                const cp2 = controlPoints[i * 2 + 1];
-                const p = points[(i + 1) % len];
-                ctx.bezierCurveTo(
-                    cp1[0], cp1[1], cp2[0], cp2[1], p[0], p[1]
+            if (drawMode === 'lineStrip') {
+                buildBezierCurve(
+                    points,
+                    smooth,
+                    closePath,
+                    shape.smoothConstraint,
+                    ctx
                 );
+            }
+            else {
+                let startIndex = 0;
+                while (startIndex < points.length - 1) {
+                    // Find the position where the line start point is
+                    // different from the end point
+                    let endIndex = startIndex + 2;
+                    const stripPoints = [points[startIndex], points[startIndex + 1]];
+                    while (endIndex < points.length) {
+                        if (points[endIndex - 1][0] !== points[endIndex][0]
+                            || points[endIndex - 1][1] !== points[endIndex][1]
+                        ) {
+                            break;
+                        }
+                        endIndex += 2;
+                        stripPoints.push(points[endIndex - 1]);
+                    }
+                    buildBezierCurve(
+                        stripPoints,
+                        smooth,
+                        closePath,
+                        shape.smoothConstraint,
+                        ctx
+                    );
+                    startIndex = endIndex;
+                }
             }
         }
         else {
             ctx.moveTo(points[0][0], points[0][1]);
             for (let i = 1, l = points.length; i < l; i++) {
-                ctx.lineTo(points[i][0], points[i][1]);
+                if (drawMode === 'lineStrip' || i % 2 === 1) {
+                    ctx.lineTo(points[i][0], points[i][1]);
+                }
+                // If the new point is the same as the previous point, it can be ignored
+                else if (points[i][0] !== points[i - 1][0]
+                    || points[i][1] !== points[i - 1][1]
+                ) {
+                    ctx.moveTo(points[i][0], points[i][1]);
+                }
             }
         }
 
         closePath && ctx.closePath();
+    }
+}
+
+function buildBezierCurve(
+    points: VectorArray[],
+    smooth: number,
+    closePath: boolean,
+    smoothConstraint: VectorArray[],
+    ctx: CanvasRenderingContext2D | PathProxy
+) {
+    const controlPoints = smoothBezier(
+        points, smooth, closePath, smoothConstraint
+    );
+
+    ctx.moveTo(points[0][0], points[0][1]);
+    const len = points.length;
+    for (let i = 0; i < (closePath ? len : len - 1); i++) {
+        const cp1 = controlPoints[i * 2];
+        const cp2 = controlPoints[i * 2 + 1];
+        const p = points[(i + 1) % len];
+        ctx.bezierCurveTo(
+            cp1[0], cp1[1], cp2[0], cp2[1], p[0], p[1]
+        );
     }
 }

--- a/src/graphic/shape/Polyline.ts
+++ b/src/graphic/shape/Polyline.ts
@@ -12,6 +12,7 @@ export class PolylineShape {
     percent?: number = 1
     smooth?: number = 0
     smoothConstraint?: VectorArray[] = null
+    drawMode?: 'lineStrip' | 'lines' = 'lineStrip'
 }
 
 export interface PolylineProps extends PathProps {

--- a/test/lineStrip.html
+++ b/test/lineStrip.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Animation</title>
+    <script src="../dist/zrender.js"></script>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+        html, body, #main {
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+<body>
+    <div id="main"></div>
+    <script type="text/javascript">
+        var main = document.getElementById('main');
+        // 初始化zrender
+        var zr = zrender.init(main);
+
+        var polyline1 = new zrender.Polyline({
+            shape: {
+                points: [
+                    [100, 50],
+                    [200, 100],
+                    [200, 200],
+                    [300, 400],
+                    [300, 400],
+                    [200, 350],
+                    [200, 350],
+                    [100, 400]
+                ],
+                drawMode: 'lines'
+            },
+            style: {
+                fill: 'red',
+                lineWidth: 2
+            }
+        });
+        zr.add(polyline1);
+
+        zr.add(new zrender.Text({
+            style: {
+                text: 'drawMode: lines',
+                x: 150,
+                y: 20
+            }
+        }));
+
+        var polyline2 = new zrender.Polyline({
+            shape: {
+                points: [
+                    [400, 50],
+                    [500, 100],
+
+                    [500, 200],
+                    [600, 400],
+
+                    [600, 400],
+                    [500, 350],
+
+                    [500, 350],
+                    [400, 400]
+                ],
+                drawMode: 'lines',
+                smooth: 0.8
+            },
+            style: {
+                fill: 'blue',
+                lineWidth: 2
+            }
+        });
+        zr.add(polyline2);
+
+        zr.add(new zrender.Text({
+            style: {
+                text: 'drawMode: lines, with smooth',
+                x: 450,
+                y: 20
+            }
+        }));
+
+        var polyline3 = new zrender.Polyline({
+            shape: {
+                points: [
+                    [700, 50],
+                    [800, 100],
+                ],
+                smooth: 0.8
+            },
+            style: {
+                fill: 'green',
+                lineWidth: 2
+            }
+        });
+        zr.add(polyline3);
+
+        var polyline4 = new zrender.Polyline({
+            shape: {
+                points: [
+                    [800, 200],
+                    [900, 400],
+                    [800, 350],
+                    [700, 400]
+                ],
+                smooth: 0.8
+            },
+            style: {
+                fill: 'green',
+                lineWidth: 2
+            }
+        });
+        zr.add(polyline4);
+
+        zr.add(new zrender.Text({
+            style: {
+                text: 'drawMode: lineStrip, with smooth',
+                x: 750,
+                y: 20
+            }
+        }));
+    </script>
+</body>
+</html>


### PR DESCRIPTION
The current implementation of `Polyline` supports only consecutive line segments, e.g. `[[100, 10], [200, 20], [300, 33]]` means lines from `[100, 10]` to `[200, 20]` and `[200, 20]` to `[300, 33]`. But if we want to draw non-consecutive lines like `[100, 10]` to `[200, 20]` and `[400, 40]` to `[300, 33]`, we can only use two polylines, which is both more tedious to write and less efficient.

In this PR, I propose **a new interface `drawMode: 'lineStrip' | 'lines'` for `Polyline`**. Its default value is `'lineStrip'`, which ensures compatibility with the old API.

> The concept is borrowed from OpenGL with `GL_LINE_STRIP` (continuous series of connected line segment) `GL_LINES` (treating every pair of vertices as an independent line segment).

```ts
new zrender.Polyline({
    shape: {
        points: [
            [400, 50],
            [500, 100],

            [500, 200],
            [600, 400],

            [600, 400],
            [500, 350],

            [500, 350],
            [400, 400]
        ],
        drawMode: 'lines',
        smooth: 0.8
    }
});
```

![image](https://github.com/user-attachments/assets/06fecea2-1686-428a-a2a2-f3a76a2929cf)

