### PR TITLE
fix(path): revert #1096 to be path.setData

### DIFF
--- a/src/core/PathProxy.ts
+++ b/src/core/PathProxy.ts
@@ -389,7 +389,7 @@ export default class PathProxy {
         for (let i = 0; i < len; i++) {
             appendSize += path[i].len();
         }
-        if (hasTypedArray && (this.data instanceof Float32Array || !this.data)) {
+        if (hasTypedArray && (this.data instanceof Float32Array)) {
             this.data = new Float32Array(offset + appendSize);
         }
         for (let i = 0; i < len; i++) {

--- a/src/tool/path.ts
+++ b/src/tool/path.ts
@@ -389,7 +389,7 @@ function createPathOptions(str: string, opts: SVGPathOption): InnerSVGPathOption
     const innerOpts: InnerSVGPathOption = extend({}, opts);
     innerOpts.buildPath = function (path: PathProxy | CanvasRenderingContext2D) {
         if (isPathProxy(path)) {
-            path.appendPath(pathProxy);
+            path.setData(pathProxy.data);
             // Svg and vml renderer don't have context
             const ctx = path.getContext();
             if (ctx) {


### PR DESCRIPTION
#1096 changes `path.setData(pathProxy.data);` into `path.appendPath(pathProxy);` to support compoundPath but it causes appending path data for unexpected multiple times (see demo at echarts/test/geo-svg-demo.html).

This PR reverts the changes and I will find another way to support compoundPath later.