### PR TITLE
fix(wrapText): trim lines

### DIFF
--- a/src/graphic/helper/parseText.ts
+++ b/src/graphic/helper/parseText.ts
@@ -703,7 +703,9 @@ function wrapText(
             continue;
         }
 
-        const chWidth = getWidth(ch, font);
+        // Check if first char of line is empty
+        const firstCharIsEmpty = !line && ch === ' ';
+        const chWidth = firstCharIsEmpty ? 0 : getWidth(ch, font);
         const inWord = isBreakAll ? false : !isWordBreakChar(ch);
 
         if (!lines.length
@@ -803,6 +805,15 @@ function wrapText(
     if (lines.length === 1) {
         // No new line.
         accumWidth += lastAccumWidth;
+    }
+
+    // Remove last empty chars from each line.
+    const emptySpaceWidth = getWidth(' ', font);
+    for (var index = 0; index < lines.length; index++) {
+        lines[index] = lines[index].replace(/( )+$/, () => {
+            linesWidths[index] -= emptySpaceWidth;
+            return '';
+        })
     }
 
     return {


### PR DESCRIPTION
Currently, when using `overflow: break` on `Text`, the system will break the line even if the edge characters are empty spaces. This PR fixes it by skipping the width calculation when the first character is an empty space and then trims each line at the end. It also recalculates the right `lineWidths` and renders properly both with `textAlign: left` and `textAlign: right`.


Before: 
<img width="259" alt="Capture d’écran 2024-12-23 à 12 19 32" src="https://github.com/user-attachments/assets/a594c704-e753-4bed-8244-00a009ffd2ab" />
<img width="259" alt="Capture d’écran 2024-12-23 à 12 20 48" src="https://github.com/user-attachments/assets/e317d1f5-b92f-4b28-97e1-6d4043b952d8" />

After:
<img width="259" alt="Capture d’écran 2024-12-23 à 12 19 41" src="https://github.com/user-attachments/assets/46deb6a7-9495-4a8d-a666-374115efab79" />
<img width="259" alt="Capture d’écran 2024-12-23 à 12 20 39" src="https://github.com/user-attachments/assets/466e17fe-2fcd-48e1-9c6c-0611301bdd9d" />


