### PR TITLE
fix(env): improve env detection compatibility for Node

### DIFF
--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -40,7 +40,8 @@ else if (typeof document === 'undefined' && typeof self !== 'undefined') {
 else if (
     !env.hasGlobalWindow
     || 'Deno' in window
-    || (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Node.js') > -1)
+    || (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string'
+        && navigator.userAgent.indexOf('Node.js') > -1)
 ) {
     // In node
     env.node = true;

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -37,7 +37,11 @@ else if (typeof document === 'undefined' && typeof self !== 'undefined') {
     // In worker
     env.worker = true;
 }
-else if (!env.hasGlobalWindow || 'Deno' in window || (navigator?.userAgent?.indexOf('Node.js') === 0)) {
+else if (
+    !env.hasGlobalWindow
+    || 'Deno' in window
+    || (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Node.js') > -1)
+) {
     // In node
     env.node = true;
     env.svgSupported = true;
@@ -85,29 +89,31 @@ function detect(ua: string, env: Env) {
     env.touchEventsSupported = 'ontouchstart' in window && !browser.ie && !browser.edge;
     env.pointerEventsSupported = 'onpointerdown' in window
         && (browser.edge || (browser.ie && +browser.version >= 11));
-    env.domSupported = typeof document !== 'undefined';
 
-    const style = document.documentElement.style;
+    const domSupported = env.domSupported = typeof document !== 'undefined';
+    if (domSupported) {
+        const style = document.documentElement.style;
 
-    env.transform3dSupported = (
-        // IE9 only supports transform 2D
-        // transform 3D supported since IE10
-        // we detect it by whether 'transition' is in style
-        (browser.ie && 'transition' in style)
-        // edge
-        || browser.edge
-        // webkit
-        || (('WebKitCSSMatrix' in window) && ('m11' in new WebKitCSSMatrix()))
-        // gecko-based browsers
-        || 'MozPerspective' in style
-    ) // Opera supports CSS transforms after version 12
-      && !('OTransition' in style);
+        env.transform3dSupported = (
+            // IE9 only supports transform 2D
+            // transform 3D supported since IE10
+            // we detect it by whether 'transition' is in style
+            (browser.ie && 'transition' in style)
+            // edge
+            || browser.edge
+            // webkit
+            || (('WebKitCSSMatrix' in window) && ('m11' in new WebKitCSSMatrix()))
+            // gecko-based browsers
+            || 'MozPerspective' in style
+        ) // Opera supports CSS transforms after version 12
+          && !('OTransition' in style);
 
-    // except IE 6-8 and very old firefox 2-3 & opera 10.1
-    // other browsers all support `transform`
-    env.transformSupported = env.transform3dSupported
-        // transform 2D is supported in IE9
-        || (browser.ie && +browser.version >= 9);
+        // except IE 6-8 and very old firefox 2-3 & opera 10.1
+        // other browsers all support `transform`
+        env.transformSupported = env.transform3dSupported
+            // transform 2D is supported in IE9
+            || (browser.ie && +browser.version >= 9);
+    }
 
 }
 

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -37,7 +37,7 @@ else if (typeof document === 'undefined' && typeof self !== 'undefined') {
     // In worker
     env.worker = true;
 }
-else if (!env.hasGlobalWindow || 'Deno' in window) {
+else if (!env.hasGlobalWindow || 'Deno' in window || (navigator?.userAgent?.indexOf('Node.js') === 0)) {
     // In node
     env.node = true;
     env.svgSupported = true;


### PR DESCRIPTION
The React Native test environment *is* Node but sets up a window global: https://github.com/facebook/react-native/blob/7a85b911254dbae9fac4c6d8a862a20c33e0b36a/packages/react-native/Libraries/Core/setUpGlobals.js#L18

Reintroduce the navigator.userAgent check as a fallback for detecting a Node environment