### PR TITLE
fix(svg): fix `stop-opacity` is not parsed by SVG parser

### DIFF
--- a/src/tool/color.ts
+++ b/src/tool/color.ts
@@ -93,7 +93,7 @@ function clampCssFloat(f: number): number {  // Clamp to float 0.0 .. 1.0.
     return f < 0 ? 0 : f > 1 ? 1 : f;
 }
 
-function parseCssInt(val: string | number): number {  // int or percentage.
+export function parseCssInt(val: string | number): number {  // int or percentage.
     let str = val as string;
     if (str.length && str.charAt(str.length - 1) === '%') {
         return clampCssByte(parseFloat(str) / 100 * 255);
@@ -101,7 +101,7 @@ function parseCssInt(val: string | number): number {  // int or percentage.
     return clampCssByte(parseInt(str, 10));
 }
 
-function parseCssFloat(val: string | number): number {  // float or percentage.
+export function parseCssFloat(val: string | number): number {  // float or percentage.
     let str = val as string;
     if (str.length && str.charAt(str.length - 1) === '%') {
         return clampCssFloat(parseFloat(str) / 100);

--- a/src/tool/parseSVG.ts
+++ b/src/tool/parseSVG.ts
@@ -19,6 +19,7 @@ import RadialGradient, { RadialGradientObject } from '../graphic/RadialGradient'
 import Gradient, { GradientObject } from '../graphic/Gradient';
 import TSpan, { TSpanStyleProps } from '../graphic/TSpan';
 import { parseXML } from './parseXML';
+import * as colorTool from './color';
 
 
 interface SVGParserOption {
@@ -627,9 +628,19 @@ function parseGradientColorStops(xmlNode: SVGElement, gradient: GradientObject):
             // <stop stop-color="red"/>
             const styleVals = {} as Dictionary<string>;
             parseInlineStyle(stop, styleVals, styleVals);
-            const stopColor = styleVals.stopColor
+            let stopColor = styleVals.stopColor
                 || stop.getAttribute('stop-color')
                 || '#000000';
+            const stopOpacity = styleVals.stopOpacity
+                || stop.getAttribute('stop-opacity');
+            if (stopOpacity) {
+                const rgba = colorTool.parse(stopColor);
+                const stopColorOpacity = rgba && rgba[3];
+                if (stopColorOpacity) {
+                    rgba[3] *= colorTool.parseCssFloat(stopOpacity);
+                    stopColor = colorTool.stringify(rgba, 'rgba');
+                }
+            }
 
             gradient.colorStops.push({
                 offset: offset,

--- a/test/parser-svg-stop-opacity.html
+++ b/test/parser-svg-stop-opacity.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Parse SVG stop-opacity</title>
+    <script src="../dist/zrender.js"></script>
+</head>
+<body>
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        #main {
+            padding: 16px;
+        }
+        #chart-container,
+        #original-svg svg {
+            width: 100px;
+            height: 20px;
+            margin-bottom: 10px;
+        }
+    </style>
+    <div id="main">
+        ZRender.parseSVG:
+        <div id="chart-container"></div>
+        Original SVG:
+        <div id="original-svg"></div>
+    </div>
+    <script type="text/javascript">
+        var zr = zrender.init(document.getElementById('chart-container'), {
+            renderer: 'svg'
+        });
+        var svg = `
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+                <defs>
+                    <linearGradient id="gr" gradientUnits="userSpaceOnUse" x2="100">
+                        <stop offset="0" stop-color="rgba(0,0,255,.5)" stop-opacity="0.5" />
+                        <stop offset="1" stop-color="rgba(255,0,0,.5)" stop-opacity="0" />
+                    </linearGradient>
+                </defs>
+                <rect width="100" height="20" style="fill:url(#gr)"/>
+            </svg>
+        `;
+        var result = zrender.parseSVG(svg);
+        zr.add(result.root);
+        document.getElementById('original-svg').innerHTML = svg;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fix (partially) https://github.com/apache/echarts/issues/18407#issuecomment-2738836773

| Before | After |
| :----: | :----: |
| ![image](https://github.com/user-attachments/assets/fabf3e92-2a15-46cf-812a-3b17477ec47a) | ![image](https://github.com/user-attachments/assets/4208de3e-b42b-414e-83e4-4040cc723fee) |
