### PR TITLE
feat(cursor): Save the latest cursor to mouse event. 

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -220,7 +220,8 @@ class Handler extends Eventful {
         const hoveredTarget = hovered.target;
 
         const proxy = this.proxy;
-        proxy.setCursor && proxy.setCursor(hoveredTarget ? hoveredTarget.cursor : 'default');
+        const cursorStyle = event.zrCursorStyle = hoveredTarget ? hoveredTarget.cursor : 'default';
+        proxy.setCursor && proxy.setCursor(cursorStyle);
 
         // Mouse out on previous hovered element
         if (lastHoveredTarget && hoveredTarget !== lastHoveredTarget) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -52,6 +52,8 @@ type ZREventProperties = {
     zrEventControl: 'no_globalout' | 'only_globalout'
 
     zrByTouch: boolean
+
+    zrCursorStyle: string
 }
 
 export type ZRRawMouseEvent = MouseEvent & ZREventProperties


### PR DESCRIPTION
Save the latest cursor to mouse event. The upper application can use it on dragging cursor style - as the lowest precedence.