### PR TITLE
add `passive: false` explicitly as default opt

### DIFF
--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -267,7 +267,13 @@ export function addEventListener(
     //     // By default, the third param of el.addEventListener is `capture: false`.
     //     : void 0;
     // el.addEventListener(name, handler /* , opts */);
-    el.addEventListener(name, handler, opt);
+    el.addEventListener(
+        name,
+        handler,
+        typeof opt === 'boolean'
+            ? { passive: false, capture: opt }
+            : { passive: false, ...opt },
+    );
 }
 
 /**


### PR DESCRIPTION
add `passive: false` explicitly as default opt to remove below warning in echarts:
- [Violation] Added non-passive event listener to a scroll-blocking 'mousewheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952

choose `passive: false` rather than `passive: true` is to avoid below error when doing dataZoom
- `Unable to preventDefault inside passive event listener invocation.`

Although there are annotations on no neat way to using passive, I personally think it is higher priority to make this great package without warining and error, rather than not doing anything but endless wait to deal with this tiny potential performance issue. Just my two cents.