### PR TITLE
Fix text bounding rect

### DIFF
--- a/src/contain/text.ts
+++ b/src/contain/text.ts
@@ -106,7 +106,7 @@ export function measureWidth(fontMeasureInfo: FontMeasureInfo, text: string): nu
 
 
 /**
- *
+ * @deprecated See `getBoundingRect`.
  * Get bounding rect for inner usage(TSpan)
  * Which not include text newline.
  */
@@ -128,6 +128,9 @@ export function innerGetBoundingRect(
 }
 
 /**
+ * @deprecated Use `(new Text(...)).getBoundingRect()` or `(new TSpan(...)).getBoundingRect()` instead.
+ *  This method behaves differently from `Text#getBoundingRect()` - e.g., it does not support the overflow
+ *  strategy, and only has single line height even if multiple lines.
  *
  * Get bounding rect for outer usage. Compatitable with old implementation
  * Which includes text newline.

--- a/src/graphic/TSpan.ts
+++ b/src/graphic/TSpan.ts
@@ -1,10 +1,10 @@
 import Displayable, { DisplayableProps, DisplayableStatePropNames } from './Displayable';
-import { getBoundingRect } from '../contain/text';
 import BoundingRect from '../core/BoundingRect';
 import { PathStyleProps, DEFAULT_PATH_STYLE } from './Path';
 import { createObject, defaults } from '../core/util';
-import { FontStyle, FontWeight, TextAlign, TextVerticalAlign } from '../core/types';
+import { FontStyle, FontWeight } from '../core/types';
 import { DEFAULT_FONT } from '../core/platform';
+import { tSpanCreateBoundingRect, tSpanHasStroke } from './helper/parseText';
 
 export interface TSpanStyleProps extends PathStyleProps {
 
@@ -53,9 +53,7 @@ class TSpan extends Displayable<TSpanProps> {
     style: TSpanStyleProps
 
     hasStroke() {
-        const style = this.style;
-        const stroke = style.stroke;
-        return stroke != null && stroke !== 'none' && style.lineWidth > 0;
+        return tSpanHasStroke(this.style);
     }
 
     hasFill() {
@@ -81,31 +79,8 @@ class TSpan extends Displayable<TSpanProps> {
     }
 
     getBoundingRect(): BoundingRect {
-        const style = this.style;
-
         if (!this._rect) {
-            let text = style.text;
-            text != null ? (text += '') : (text = '');
-
-            const rect = getBoundingRect(
-                text,
-                style.font,
-                style.textAlign as TextAlign,
-                style.textBaseline as TextVerticalAlign
-            );
-
-            rect.x += style.x || 0;
-            rect.y += style.y || 0;
-
-            if (this.hasStroke()) {
-                const w = style.lineWidth;
-                rect.x -= w / 2;
-                rect.y -= w / 2;
-                rect.width += w;
-                rect.height += w;
-            }
-
-            this._rect = rect;
+            this._rect = tSpanCreateBoundingRect(this.style);
         }
 
         return this._rect;

--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -544,6 +544,13 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
             const boxY = adjustTextY(baseY, outerHeight, verticalAlign);
             needDrawBg && this._renderBackground(style, style, boxX, boxY, outerWidth, outerHeight);
         }
+        // PENDING:
+        //  Should text bounding rect contains style.padding, style.width, style.height when NO background
+        //  and border displayed? It depends on how to define "boundingRect". HTML `getBoundingClientRect`
+        //  contains padding in that case. But currently ZRText does not.
+        //  If implement that, an extra invisible Rect may need to be added as the placeholder for the bounding
+        //  rect computation, considering animation of padding. But will it degrade performance for the most
+        //  used plain texts cases?
 
         // `textBaseline` is set as 'middle'.
         textY += lineHeight / 2;

--- a/src/graphic/Text.ts
+++ b/src/graphic/Text.ts
@@ -6,7 +6,8 @@ import {
     TextAlign, TextVerticalAlign, ImageLike, Dictionary, MapToType, FontWeight, FontStyle, NullUndefined
 } from '../core/types';
 import {
-    parseRichText, parsePlainText, CalcInnerTextOverflowAreaOut, calcInnerTextOverflowArea
+    parseRichText, parsePlainText, CalcInnerTextOverflowAreaOut, calcInnerTextOverflowArea,
+    tSpanCreateBoundingRect2,
 } from './helper/parseText';
 import TSpan, { TSpanStyleProps } from './TSpan';
 import { retrieve2, each, normalizeCssArray, trim, retrieve3, extend, keys, defaults } from '../core/util';
@@ -332,7 +333,7 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
         }
     }
 
-     updateTransform() {
+    updateTransform() {
         const innerTransformable = this.innerTransformable;
         if (innerTransformable) {
             innerTransformable.updateTransform();
@@ -528,7 +529,6 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
 
         const outerHeight = contentBlock.outerHeight;
         const outerWidth = contentBlock.outerWidth;
-        const contentWidth = contentBlock.contentWidth;
 
         const textLines = contentBlock.lines;
         const lineHeight = contentBlock.lineHeight;
@@ -559,6 +559,7 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
         }
 
         let defaultLineWidth = 0;
+        let usingDefaultStroke = false;
         let useDefaultFill = false;
         const textFill = getFill(
             'fill' in style
@@ -580,15 +581,11 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
                     // we give the auto lineWidth to display the given stoke color.
                     && (!defaultStyle.autoStroke || useDefaultFill)
                 )
-                ? (defaultLineWidth = DEFAULT_STROKE_LINE_WIDTH, defaultStyle.stroke)
+                ? (defaultLineWidth = DEFAULT_STROKE_LINE_WIDTH, usingDefaultStroke = true, defaultStyle.stroke)
                 : null
         );
 
         const hasShadow = style.textShadowBlur > 0;
-
-        const fixedBoundingRect = style.width != null
-            && (style.overflow === 'truncate' || style.overflow === 'break' || style.overflow === 'breakAll');
-        const calculatedLineHeight = contentBlock.calculatedLineHeight;
 
         for (let i = 0; i < textLines.length; i++) {
             const el = this._getOrCreateChild(TSpan);
@@ -633,19 +630,27 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
 
             textY += lineHeight;
 
-            if (fixedBoundingRect) {
-                el.setBoundingRect(new BoundingRect(
-                    adjustTextX(subElStyle.x, contentWidth, subElStyle.textAlign as TextAlign),
-                    adjustTextY(subElStyle.y, calculatedLineHeight, subElStyle.textBaseline as TextVerticalAlign),
-                    /**
-                     * Text boundary should be the real text width.
-                     * Otherwise, there will be extra space in the
-                     * bounding rect calculated.
-                     */
-                    contentWidth,
-                    calculatedLineHeight
-                ));
-            }
+            // Always set tspan bounding rect to guarantee the consistency if users lays out based
+            // on these bounding rects.
+            el.setBoundingRect(tSpanCreateBoundingRect2(
+                subElStyle,
+                contentBlock.contentWidth,
+                contentBlock.calculatedLineHeight,
+                // Should text bounding rect includes text stroke width?
+                // Pros:
+                //   - Intuitively, and by convention, bounding rect of `Path` always includes stroke width.
+                // Cons:
+                //   - It's unpredictable for users whether "auto stroke" is applied. If stroke width is included
+                //     and multiple texts are laid out based on its bounding rect, the position of texts may vary
+                //     and is unpredictable - especially in limited space (e.g., see echarts pie label cases).
+                //   - "auto stroke" attempts to use the same color as the background to make the border to be
+                //     invisible in most cases, thus it might be more reasonable to be excluded from bounding rect.
+                // Conclusion:
+                //   - If users specifies style.stroke, it will be included into the bounding rect as normal.
+                //     Otherwise, keep the stroke width as `0` in this case to guarantee consistency of bounding
+                //     rect based layout, regardless of whether "auto stroke" is applied.
+                usingDefaultStroke ? 0 : null
+            ));
         }
     }
 
@@ -801,6 +806,7 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
         const defaultStyle = this._defaultStyle;
         let useDefaultFill = false;
         let defaultLineWidth = 0;
+        let usingDefaultStroke = false;
         const textFill = getFill(
             'fill' in tokenStyle ? tokenStyle.fill
                 : 'fill' in style ? style.fill
@@ -812,9 +818,9 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
                 : (
                     !bgColorDrawn
                     && !parentBgColorDrawn
-                    // See the strategy explained above.
+                    // See the strategy explained `_updatePlainTexts`.
                     && (!defaultStyle.autoStroke || useDefaultFill)
-                ) ? (defaultLineWidth = DEFAULT_STROKE_LINE_WIDTH, defaultStyle.stroke)
+                ) ? (defaultLineWidth = DEFAULT_STROKE_LINE_WIDTH, usingDefaultStroke = true, defaultStyle.stroke)
                 : null
         );
 
@@ -852,14 +858,13 @@ class ZRText extends Displayable<TextProps> implements GroupLike {
             subElStyle.fill = textFill;
         }
 
-        const textWidth = token.contentWidth;
-        const textHeight = token.contentHeight;
         // NOTE: Should not call dirtyStyle after setBoundingRect. Or it will be cleared.
-        el.setBoundingRect(new BoundingRect(
-            adjustTextX(subElStyle.x, textWidth, subElStyle.textAlign as TextAlign),
-            adjustTextY(subElStyle.y, textHeight, subElStyle.textBaseline as TextVerticalAlign),
-            textWidth,
-            textHeight
+        el.setBoundingRect(tSpanCreateBoundingRect2(
+            subElStyle,
+            token.contentWidth,
+            token.contentHeight,
+            // See the strategy explained `_updatePlainTexts`.
+            usingDefaultStroke ? 0 : null
         ));
     }
 

--- a/test/text.html
+++ b/test/text.html
@@ -8,14 +8,13 @@
 </head>
 <body style="margin:0">
 
-    <div style="margin: 20px;">
+    <div style="position: fixed; top: 0; background: #fff; z-index: 999; padding: 10px; border: 1px solid #ddd; box-shadow: #ddd 0 2px 8px;">
     <button style="color:blue;" onclick="showBoundingRect()">Show boundingRect</button>
+    <button style="color:blue;" onclick="showBoundingRectBeforeAddingToZr()">Show boundingRect before adding to ZR</button>
     </div>
-    <div id="main" style="width:1200px;height:2200px;margin:0;"></div>
+    <div id="main" style="position: relative; width: 1200px; height: 2200px; margin: 0; margin-top: 60px;"></div>
 
     <script type="text/javascript">
-
-    var showBoundingRect;
 
     var Text = zrender.Text;
     var Line = zrender.Line;
@@ -25,7 +24,7 @@
         renderer: window.__ZRENDER__DEFAULT__RENDERER__
     });
 
-    showBoundingRect = function () {
+    function showBoundingRect() {
         console.time('boundingRect');
         zr.storage.traverse(function (el) {
             if (el.type === 'text') {
@@ -53,6 +52,44 @@
         console.timeEnd('boundingRect');
     }
 
+    function showBoundingRectBeforeAddingToZr() {
+        console.time('showBoundingRectBeforeAddingToZr');
+        for (var idx = 0; idx < textNeverAddToZrList.length; idx++) {
+            var el = textNeverAddToZrList[idx];
+            if (el.type === 'text') {
+                var rect = el.getBoundingRect();
+
+                zr.add(new Rect({
+                    shape: {
+                        x: rect.x, y: rect.y, width: rect.width, height: rect.height
+                    },
+                    x: el.x,
+                    y: el.y,
+                    rotation: el.rotation,
+                    scaleX: el.scaleX,
+                    scaleY: el.scaleY,
+                    originX: el.originX,
+                    originY: el.originY,
+                    style: {
+                        fill: null,
+                        stroke: zrender.color.random(),
+                        lineWidth: 1
+                    }
+                }));
+            }
+        }
+        console.timeEnd('showBoundingRectBeforeAddingToZr');
+    }
+
+    function createText(textProps) {
+        var textNeverAddToZr = new Text(zrender.util.clone(textProps));
+        textNeverAddToZrList.push(textNeverAddToZr);
+
+        var textReal = new Text(textProps);
+        zr.add(textReal);
+    }
+
+    var textNeverAddToZrList = [];
     var zrWidth = zr.getWidth();
     var zrHeight = zr.getHeight();
     var unit = 100;
@@ -89,7 +126,7 @@
         }));
     }
 
-    zr.add(new Text({
+    createText({
         style: {
             x: 0,
             y: 0,
@@ -100,9 +137,9 @@
             font: '18px Microsoft Yahei'
         },
         draggable: true
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 100,
         y: 100,
         style: {
@@ -117,9 +154,9 @@
             font: '18px Microsoft Yahei'
         },
         draggable: true
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 200,
         y: 100,
         rotation: 2,
@@ -135,9 +172,9 @@
             font: '18px Microsoft Yahei'
         },
         draggable: true
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 100,
         y: 200,
         rotation: -1,
@@ -157,7 +194,7 @@
             verticalAlign: 'bottom'
         },
         draggable: true
-    }));
+    });
 
     zr.add(new Rect({
         x: 300,
@@ -169,7 +206,7 @@
             fill: '#333'
         }
     }));
-    zr.add(new Text({
+    createText({
         x: 300,
         y: 100,
         style: {
@@ -179,9 +216,9 @@
             fill: '#fff',
             font: '16px Microsoft Yahei'
         }
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 400,
         y: 50,
         style: {
@@ -192,9 +229,9 @@
             align: 'right',
             verticalAlign: 'middle'
         }
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 500,
         y: 50,
         style: {
@@ -205,9 +242,9 @@
             align: 'center',
             verticalAlign: 'bottom'
         }
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 600,
         y: 0,
         style: {
@@ -221,9 +258,9 @@
             textShadowOffsetX: 5,
             textShadowOffsetY: 10
         }
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 700,
         y: 0,
         style: {
@@ -239,9 +276,9 @@
             textShadowOffsetX: 5,
             textShadowOffsetY: 10
         }
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         x: 600,
         y: 100,
         rotation: -Math.PI / 16,
@@ -270,10 +307,10 @@
             boxShadowOffsetX: 5,
             boxShadowOffsetY: 10
         }
-    }));
+    });
 
 
-    zr.add(new Text({
+    createText({
         x: 100,
         y: 300,
         style: {
@@ -284,10 +321,10 @@
             padding: [10, 20, 30, 40],
             backgroundColor: 'rgba(124, 0, 123, 0.4)'
         }
-    }));
+    });
 
 
-    zr.add(new Text({
+    createText({
         style: {
             x: 200,
             y: 300,
@@ -412,9 +449,9 @@
             }
         },
         draggable: true
-    }));
+    });
 
-    zr.add(new Text({
+    createText({
         rotation: -0.1,
         x: 500,
         y: 900,
@@ -471,10 +508,10 @@
             }
         },
         draggable: true
-    }));
+    });
 
 
-    zr.add(new Text({
+    createText({
         rotation: -0.1,
         x: 500,
         y: 1300,
@@ -507,12 +544,65 @@
             }
         },
         draggable: true
-    }));
+    });
 
-
-
-
-
+    createText({
+        x: 100,
+        y: 1300,
+        style: {
+            x: 0,
+            y: 0,
+            padding: 10,
+            text: 'Plain text, only padding 10, no visible outer parts',
+            fill: 'rgba(100, 50, 0, 1)',
+            font: '12px Arial'
+        }
+    });
+    createText({
+        x: 100,
+        y: 1400,
+        style: {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            text: 'Plain text, width 10, height: 10,\nno visible outer parts.\noverflow:undefined',
+            fill: 'rgba(100, 50, 0, 1)',
+            font: '12px Arial'
+        }
+    });
+    createText({
+        x: 300,
+        y: 1400,
+        style: {
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+            text: 'Plain text, width 200, height: 100,\nno visible outer parts.\noverflow:undefined',
+            fill: 'rgba(100, 50, 0, 1)',
+            font: '12px Arial'
+        }
+    });
+    createText({
+        x: 100,
+        y: 1500,
+        style: {
+            x: 0,
+            y: 0,
+            padding: 10,
+            text: 'Rich text, {a|only padding 10}, no visible outer parts',
+            fill: 'rgba(100, 50, 0, 1)',
+            font: '12px Arial',
+            rich: {
+                a: {
+                    font: '12px Arial',
+                    backgroundColor: 'rgba(100, 50, 0, 0.5)',
+                    padding: [15, 0, 0, 0],
+                }
+            }
+        }
+    });
 
 
     function getDotStyle(color) {
@@ -544,7 +634,7 @@
         ['#c23531','#2f4554', '#61a0a8', '#d48265', '#91c7ae','#749f83',  '#ca8622', '#bda29a','#6e7074', '#546570', '#c4ccd3']
     );
 
-    zr.add(new Text({
+    createText({
         rotation: -0.1,
         x: 800,
         y: 1100,
@@ -559,7 +649,7 @@
             rich: styles.rich
         },
         draggable: true
-    }));
+    });
 
     </script>
 </body>


### PR DESCRIPTION
## text bounding rect consistency
Previously, plain text bounding rect is inconsistent (contain stroke width or not) according to style.width & style.overflow (even if no wrapping or truncation happen and text is visually the same). This commit makes it consistent. 

## text bounding rect include stroke
Previously, the bounding rect varies and unpredictable according to the internal auto-stroke application:
+ If auto stroke is applied, there are 1px extra stroke, otherwise not. It's discernible and matters in compact layout of multiple labels.
+ plain text: if `style.width` & `style.overflow` are specified, exclude stroke, otherwise include stroke.
+ rich text: always exclude stroke

This commit exclude auto-stroke width uniformly, since auto-stroke using the same color as background to make the border invisible. 

Should text bounding rect includes text stroke width?
+ Pros:
    - Intuitively, and by convention, bounding rect of `Path` always includes stroke width.
+ Cons:
    - It's unpredictable for users whether "auto stroke" is applied. If stroke width is included and multiple texts are laid out based on its bounding rect, the position of texts may vary and is unpredictable - especially in limited space (e.g., see echarts pie label cases).
    - "auto stroke" attempts to use the same color as the background to make the border to be invisible in most cases, thus it might be more reasonable to be excluded from bounding rect.
+ Conclusion:
    - If users specifies style.stroke, it will be included into the bounding rect as normal. Otherwise, keep the stroke width as `0` in this case to guarantee consistency of bounding rect based layout, regardless of whether "auto stroke" is applied.

## Deprecate `src/contain/text.ts` `getBoundingRect`
Use `(new Text(...)).getBoundingRect()` or `(new TSpan(...)).getBoundingRect()` instead.
It behave differently from Text#getBoundingRect, and unexpectedly when text contains "\n".
The current effect:
<img width="57" height="59" alt="zr_getBoundingRect_previous" src="https://github.com/user-attachments/assets/ba4c91db-709f-4261-befc-5dfed9cf4952" />
The red border is the return of `contain/text.ts` `getBoundingRect`, but the blue border is the actual boundingRect if rendering by ZRText.


---
## PENDING
Should text bounding rect includes `style.padding`, `style.width`, `style.height` when NO background and border displayed? It depends on how to define that. HTML `getBoundingClientRect` contain padding in that case. But currently ZRText does not.
If implement that, an extra invisible Rect may need to be added as the placeholder for the bounding rect computation, considering animation of padding. But will it degrades performance for the most commonly used plain texts cases?
