### PR TITLE
fix(graphic/Image):修复图片未加载时获取尺寸不正确的问题

### DIFF
--- a/src/graphic/Image.ts
+++ b/src/graphic/Image.ts
@@ -8,6 +8,7 @@ import BoundingRect from '../core/BoundingRect';
 import { ImageLike, MapToType } from '../core/types';
 import { defaults, createObject } from '../core/util';
 import { ElementCommonState } from '../Element';
+import {isImageReady} from "./helper/image";
 
 export interface ImageStyleProps extends CommonStyleProps {
     image?: string | ImageLike
@@ -117,7 +118,14 @@ class ZRImage extends Displayable<ImageProps> {
                 style.x || 0, style.y || 0, this.getWidth(), this.getHeight()
             );
         }
-        return this._rect;
+
+        const rect = this._rect;
+        //If the image hasn't loaded, ensure to obtain the correct value next time.
+        if (this.__image && !isImageReady(this.__image)) {
+            this._rect = null
+        }
+
+        return rect;
     }
 }
 


### PR DESCRIPTION
当图片尚未加载完成时，确保下次能获取到正确的尺寸值。通过在检测到图片未就绪时将 _rect 设为 null，从而触发重新计算。