### PR TITLE
fix(workflow): fix match pattern for changed files collection in the lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Collect changed files
         run: |
           mkdir ~/tmp/
-          git diff ${{ github.event.pull_request.base.sha }} ${{ github.sha }} --diff-filter=ACM --name-only --relative '*src/**/*.ts' > ~/tmp/changed_files
+          git diff ${{ github.event.pull_request.base.sha }} ${{ github.sha }} --diff-filter=ACM --name-only --relative '*src/*.ts' '*src/**/*.ts' > ~/tmp/changed_files
           echo -e "Changed files: \n$(cat ~/tmp/changed_files)"
 
       - name: Lint


### PR DESCRIPTION
I noticed the current match pattern for collecting the changed files can't match the files in the `src` root folder. This PR fixes that.

See https://github.com/ecomfe/zrender/actions/runs/19047336358/job/54807797177#step:7:9

The same fix has been applied for ECharts in apache/echarts#21347