### PR TITLE
fix(svg): enhance SVG encodeBase64 compatibility

### DIFF
--- a/src/svg/helper.ts
+++ b/src/svg/helper.ts
@@ -2,7 +2,7 @@
 
 import { MatrixArray } from '../core/matrix';
 import Transformable, { TransformProp } from '../core/Transformable';
-import { RADIAN_TO_DEGREE, retrieve2, logError, isFunction } from '../core/util';
+import { RADIAN_TO_DEGREE, retrieve2, logError } from '../core/util';
 import Displayable from '../graphic/Displayable';
 import { GradientObject } from '../graphic/Gradient';
 import { LinearGradientObject } from '../graphic/LinearGradient';
@@ -10,7 +10,6 @@ import Path from '../graphic/Path';
 import { ImagePatternObject, PatternObject, SVGPatternObject } from '../graphic/Pattern';
 import { RadialGradientObject } from '../graphic/RadialGradient';
 import { parse } from '../tool/color';
-import env from '../core/env';
 
 const mathRound = Math.round;
 
@@ -173,14 +172,14 @@ export function getSRTTransformString(
 }
 
 export const encodeBase64 = (function () {
-    if (env.hasGlobalWindow && isFunction(window.btoa)) {
-        return function (str: string) {
-            return window.btoa(unescape(encodeURIComponent(str)));
-        };
-    }
-    if (typeof Buffer !== 'undefined') {
+    if (typeof Buffer !== 'undefined' && typeof Buffer.from === 'function') {
         return function (str: string) {
             return Buffer.from(str).toString('base64');
+        };
+    }
+    if (typeof btoa === 'function' && typeof unescape === 'function' && typeof encodeURIComponent === 'function') {
+        return function (str: string) {
+            return btoa(unescape(encodeURIComponent(str)));
         };
     }
     return function (str: string): string {

--- a/test/svg-ssr.html
+++ b/test/svg-ssr.html
@@ -268,6 +268,38 @@
     document.getElementById('main').innerHTML = svg;
     console.timeEnd('render');
 
+    // base64
+    console.log('window SSR base64:');
+    console.log(zr.painter.toDataURL(true));
+
+    // worker base64
+    const workerSource = `
+        importScripts('${location.origin}/dist/zrender.js')
+        const zr = zrender.init(null, {
+            renderer: 'svg',
+            ssr: true,
+            width: 1200,
+            height: 1200
+        });
+        const el = new zrender.Circle({
+            x: 50,
+            y: 50,
+            shape: {
+                cx: 0,
+                cy: 0,
+                r: 25
+            },
+            style: {
+                fill: 'red'
+            }
+        });
+        zr.add(el);
+        console.log('worker SSR base64:');
+        console.log(zr.painter.toDataURL(true));
+        zr.dispose();
+    `;
+    new Worker(URL.createObjectURL(new Blob([workerSource], { type: 'application/javascript' })));
+
     // var blob = new Blob([svg], { type: 'image/svg+xml' });
     // var a = document.createElement('a');
     // a.download = 'aaa.svg';


### PR DESCRIPTION
#856 added the ability to export a base64-encoded SVG string, but it does not work in the environment without a global `window`, like Web Worker. This PR makes it possible in more environments, like Web Worker, NodeJS, Bun, and so on.

**Current Behavior:**

<img width="397" height="62" alt="image" src="https://github.com/user-attachments/assets/27457447-b71a-4d25-b94c-951de43d69d0" />

**After Fix:**

<img width="557" height="62" alt="image" src="https://github.com/user-attachments/assets/33b9bd74-88a9-4143-9afd-7cb5c95026f8" />
