### PR TITLE
fix(graphic): close path in `roundRect` helper to avoid stroke corner gap

### DIFF
--- a/src/graphic/helper/roundRect.ts
+++ b/src/graphic/helper/roundRect.ts
@@ -84,4 +84,5 @@ export function buildPath(ctx: CanvasRenderingContext2D | PathProxy, shape: {
     r4 !== 0 && ctx.arc(x + r4, y + height - r4, r4, Math.PI / 2, Math.PI);
     ctx.lineTo(x, y + r1);
     r1 !== 0 && ctx.arc(x + r1, y + r1, r1, Math.PI, Math.PI * 1.5);
+    ctx.closePath();
 }


### PR DESCRIPTION
This fixes apache/echarts#21595

In src/graphic/helper/roundRect.ts, `buildPath` does not call `closePath()` at the end.
When stroking with non-square lineCap (e.g. default `butt`), this can produce a small visual corner gap/notch at the start-end junction.

[Reproduction Demo](https://echarts.apache.org/examples/editor.html?c=bar-simple&code=XU7BisIwEL37FQN7yKWH1GXZpcseFsGbFxU8SA-jGTVQm5omYpH-u5O0zUFI3kvmMe890zhtaviD5wzg8f_QbRGfAK5rqABxREdnYzuRxalChwXsxcrUIgOx9RRoRyr-Lj7Q0upAG3SRfC1K3u2DQTcmTO53rNhh0Fqymljcx6ChRArM5zKDuWTIvxh--H6HTx7gU5ZDu9T6gHYsDKAdXTeuq3g-mQIcjFVkd1q5SwFs8iYsTGUs-3ycpExGk7hGpX0oytnjSfnJABteb28eLYlR6yMHLGf97ws&enc=deflate)

| Before | After |
| :----: | :----: |
| <img width="444" height="462" alt="image" src="https://github.com/user-attachments/assets/818261e8-3a61-4d4f-8e16-ba5eeb6f3167" /> | <img width="436" height="440" alt="image" src="https://github.com/user-attachments/assets/2e165fd9-f535-4025-b563-8b51c02ecdc6" /> |

