### PR TITLE
fix(handler): clear hovered state after mouseout. close #1035

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -243,6 +243,8 @@ class Handler extends Eventful {
             this.dispatchToElement(this._hovered, 'mouseout', event);
         }
 
+        this._hovered = new HoveredResult(0, 0);
+
         if (eventControl !== 'no_globalout') {
             // FIXME: if the pointer moving from the extra doms to realy "outside",
             // the `globalout` should have been triggered. But currently not.

--- a/test/ut/spec/Handler.test.ts
+++ b/test/ut/spec/Handler.test.ts
@@ -1,0 +1,62 @@
+import Handler from "../../../src/Handler";
+import Storage from "../../../src/Storage";
+import { Rect } from "./zrender";
+
+function makeEvent(zrX: number, zrY: number) {
+  return {
+    zrX,
+    zrY,
+    zrDelta: 0,
+    zrByTouch: false,
+    which: 1,
+  } as any;
+}
+
+describe("Handler", function () {
+  it("should fire mouseover again after mouseout from canvas and re-entering the same element", function () {
+    const storage = new Storage();
+    const proxy = {
+      on() {},
+      dispose() {},
+      setCursor() {},
+    } as any;
+    const painter = {
+      getWidth() {
+        return 200;
+      },
+      getHeight() {
+        return 200;
+      },
+    } as any;
+    const handler = new Handler(storage, painter, proxy, null, null);
+
+    const rect = new Rect({
+      shape: {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      },
+    });
+    storage.addRoot(rect);
+
+    let mouseoverCount = 0;
+    let mouseoutCount = 0;
+    rect.on("mouseover", function () {
+      mouseoverCount++;
+    });
+    rect.on("mouseout", function () {
+      mouseoutCount++;
+    });
+
+    handler.mousemove(makeEvent(10, 10));
+    expect(mouseoverCount).toBe(1);
+    expect(mouseoutCount).toBe(0);
+
+    handler.mouseout(makeEvent(150, 150));
+    expect(mouseoutCount).toBe(1);
+
+    handler.mousemove(makeEvent(10, 10));
+    expect(mouseoverCount).toBe(2);
+  });
+});


### PR DESCRIPTION
Fixes #1035

### Summary

When the pointer leaves the ZRender area from a hovered element, `mouseout` is dispatched but the internal hovered state is not cleared. If the pointer then re-enters from the same position over the same element, `mouseover` is skipped because `mousemove` still sees the previous hovered target as current.

This patch clears `_hovered` in `Handler.mouseout` so re-entering the same element correctly fires `mouseover` again.

### Root cause

In `src/Handler.ts`:

- `mouseout` dispatched the event to `this._hovered`
- but `this._hovered` remained pointing to the old element
- on the next `mousemove`, `lastHoveredTarget` and `hoveredTarget` were the same
- so the `mouseover` branch was not entered

### Change

- reset `this._hovered` to an empty `HoveredResult` in `Handler.mouseout`

### Test

Added `test/ut/spec/Handler.test.ts` covering:

1. `mousemove` into an element → `mouseover`
2. `mouseout` from canvas
3. `mousemove` back into the same element
4. `mouseover` fires again

### Validation

Passed:

```sh
npx jest --config test/ut/jest.config.js test/ut/spec/Handler.test.ts --runInBand
npx jest --config test/ut/jest.config.js --runInBand
```

Note:
- `npm run checktype` currently fails on a pre-existing upstream TypeScript issue in `src/canvas/Painter.ts`, unrelated to this change.
