### PR TITLE
fix(canvas): include custom layers in high-DPR exports

### DIFF
--- a/src/canvas/Painter.ts
+++ b/src/canvas/Painter.ts
@@ -79,6 +79,24 @@ function createRoot(width: number, height: number) {
     return domRoot;
 }
 
+function createExportBrushScope(viewWidth: number, viewHeight: number): BrushScope {
+    return {
+        inHover: false,
+        viewWidth,
+        viewHeight,
+        beforeBrushParam: {},
+    };
+}
+
+function renderLayerToCanvas(ctx: CanvasRenderingContext2D, layer: Layer): void {
+    ctx.save();
+    // A previous displayable may leave its transform on the export context.
+    // Custom layers receive an identity transform in the normal compositing path.
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    layer.renderToCanvas(ctx);
+    ctx.restore();
+}
+
 function createBuiltinLayer(
     id: string | HTMLCanvasElement,
     painter: CanvasPainter,
@@ -1250,7 +1268,7 @@ export default class CanvasPainter implements PainterBase {
                 domRoot.style.width = width + 'px';
                 domRoot.style.height = height + 'px';
 
-                eachLayer(this._i, function (layer) {
+                eachLayer(this._i, (layer) => {
                     layer.resize(width as number, height as number, this.dpr);
                 });
 
@@ -1312,25 +1330,51 @@ export default class CanvasPainter implements PainterBase {
                     ctx.drawImage(layer.dom, 0, 0, width, height);
                 }
                 else if (layer.renderToCanvas) {
-                    ctx.save();
-                    layer.renderToCanvas(ctx);
-                    ctx.restore();
+                    renderLayerToCanvas(ctx, layer);
                 }
             });
         }
         else {
-            // PENDING, echarts-gl and incremental rendering.
-            const scope: BrushScope = {
-                inHover: false,
-                viewWidth: this._width,
-                viewHeight: this._height,
-                beforeBrushParam: {},
-            };
+            let scope = createExportBrushScope(this._width, this._height);
             const displayList = this.storage.getDisplayList(true);
+
+            const otherLayers: {layer: Layer, zlevel: ZLevel}[] = [];
+            eachLayer(this._i, function (layer, zlevel) {
+                if (layer.renderToCanvas) {
+                    otherLayers.push({layer, zlevel});
+                }
+            }, EACH_LAYER_NOT_BUILTIN);
+
+            let otherLayerIdx = 0;
+            const renderOtherLayersBefore = (zlevel: ZLevel) => {
+                const firstOtherLayerIdx = otherLayerIdx;
+                while (otherLayerIdx < otherLayers.length
+                    && otherLayers[otherLayerIdx].zlevel <= zlevel
+                ) {
+                    otherLayerIdx++;
+                }
+
+                if (otherLayerIdx > firstOtherLayerIdx) {
+                    // Custom layers are not included in storage's display list. Flush
+                    // pending batches and clipping before inserting them in z-order.
+                    brushLoopFinalize(ctx, scope);
+                    for (let i = firstOtherLayerIdx; i < otherLayerIdx; i++) {
+                        renderLayerToCanvas(ctx, otherLayers[i].layer);
+                    }
+                    scope = createExportBrushScope(this._width, this._height);
+                }
+            };
+
+            let prevZlevel: ZLevel;
             for (let i = 0, len = displayList.length; i < len; i++) {
                 const el = displayList[i];
+                if (el.zlevel !== prevZlevel) {
+                    prevZlevel = el.zlevel;
+                    renderOtherLayersBefore(el.zlevel);
+                }
                 brush(ctx, el, scope);
             }
+            renderOtherLayersBefore(Infinity);
             brushLoopFinalize(ctx, scope);
         }
 

--- a/test/ut/spec/canvas/Painter.test.ts
+++ b/test/ut/spec/canvas/Painter.test.ts
@@ -1,0 +1,87 @@
+import CanvasPainter from '../../../../src/canvas/Painter';
+import Layer from '../../../../src/canvas/Layer';
+import Storage from '../../../../src/Storage';
+import {platformApi, setPlatformAPI} from '../../../../src/core/platform';
+import Rect from '../../../../src/graphic/shape/Rect';
+
+describe('CanvasPainter', function () {
+    const originalCreateCanvas = platformApi.createCanvas;
+
+    afterEach(function () {
+        setPlatformAPI({
+            createCanvas: originalCreateCanvas
+        });
+    });
+
+    it('includes custom layers in z-order when exporting above painter dpr', function () {
+        const events: string[] = [];
+
+        function createCanvas() {
+            let ctx: CanvasRenderingContext2D;
+            const canvas = {
+                getContext: () => ctx,
+                height: 100,
+                nodeName: 'CANVAS',
+                style: null,
+                width: 100
+            } as unknown as HTMLCanvasElement;
+            ctx = {
+                beginPath: jest.fn(),
+                canvas,
+                clearRect: jest.fn(),
+                fill: jest.fn(),
+                rect: jest.fn(),
+                restore: jest.fn(),
+                save: jest.fn(),
+                setTransform: jest.fn(),
+                stroke: jest.fn()
+            } as unknown as CanvasRenderingContext2D;
+            return canvas;
+        }
+
+        setPlatformAPI({createCanvas});
+
+        const storage = new Storage();
+        const root = createCanvas();
+        const painter = new CanvasPainter(root, storage, {
+            devicePixelRatio: 1,
+            width: 100,
+            height: 100
+        }, 0);
+
+        function insertCustomLayer(zlevel: number, name: string) {
+            const layer = new Layer(name, painter, 1);
+            layer.virtual = true;
+            layer.refresh = jest.fn();
+            layer.resize = jest.fn();
+            layer.renderToCanvas = jest.fn(function () {
+                events.push(name);
+            });
+            painter.insertLayer(zlevel, layer);
+            return layer;
+        }
+
+        const lowerLayer = insertCustomLayer(1, 'lower custom layer');
+        const upperLayer = insertCustomLayer(3, 'upper custom layer');
+        const rect = new Rect({
+            shape: {width: 10, height: 10}
+        });
+        rect.zlevel = 2;
+        rect.beforeBrush = function () {
+            events.push('displayable');
+        };
+        storage.addRoot(rect);
+
+        const exportedCanvas = painter.getRenderedCanvas({pixelRatio: 2});
+
+        expect(exportedCanvas.width).toBe(200);
+        expect(exportedCanvas.height).toBe(200);
+        expect(lowerLayer.renderToCanvas).toHaveBeenCalledTimes(1);
+        expect(upperLayer.renderToCanvas).toHaveBeenCalledTimes(1);
+        expect(events).toEqual([
+            'lower custom layer',
+            'displayable',
+            'upper custom layer'
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

- include non-builtin layers in `getRenderedCanvas` when the requested pixel ratio is greater than the painter DPR
- preserve z-level ordering by flushing the current brush scope before calling each custom layer `renderToCanvas` hook
- reset the export context to an identity transform for custom layers, matching the normal compositing path
- add a regression test covering custom layers below and above a built-in displayable
- fix the existing resize callback capture so TypeScript compilation succeeds on the current `master` branch

## Root cause

The normal export branch composites painter layers and calls `renderToCanvas` for non-builtin layers. The high-pixel-ratio branch instead brushes only the storage display list. Custom layers such as echarts-gl `LayerGL` are not part of that display list, so they were omitted while 2D components remained visible.

This is the underlying cause of [apache/echarts#21700](https://github.com/apache/echarts/issues/21700). The exact trigger is a requested pixel ratio greater than the painter DPR.

## Validation

- `npm test -- --runInBand` — 13 suites, 69 tests passed
- `npm run checktype`
- `npm run lint`
- `npm run build:lib`