### PR TITLE
fix(Handler): allow click through when elements are recreated between mousedown and mouseup

### DIFF
--- a/src/Handler.ts
+++ b/src/Handler.ts
@@ -466,6 +466,10 @@ util.each(['click', 'mousedown', 'mouseup', 'mousewheel', 'dblclick', 'contextme
                 // including the case that `mousedown` - `mousemove` - `mouseup`,
                 // which should be filtered, otherwise it will bring trouble to
                 // pan and zoom.
+                // If the element was removed from zrender (e.g. recreated by
+                // setOption), the reference comparison will fail but the click
+                // should still be allowed. See apache/echarts#21566.
+                && (!this._downEl || this._downEl.__zr)
                 || !this._downPoint
                 // Arbitrary value
                 || vec2.dist(this._downPoint, [event.zrX, event.zrY]) > 4


### PR DESCRIPTION
## Summary

When `setOption` is called at high frequency (>=30fps, e.g. real-time WebSocket data) between `mousedown` and `mouseup`, zrender elements are recreated. The `click` handler compares element references (`_downEl !== _upEl`), which always fails for recreated elements, causing click events (e.g. legend toggle) to never fire.

This bug is reported as [apache/echarts#21566](https://github.com/apache/echarts/issues/21566).

## Root Cause

In `Handler.ts`, the `click` handler checks:
```ts
if (this._downEl !== this._upEl) { return; }
```

When `setOption` is called between `mousedown` and `mouseup`, the display list is updated and elements are recreated. The `_downEl` reference (stored during `mousedown`) points to the old, removed element, while `_upEl` (set during `mouseup`) points to the new element. The reference comparison always fails, cancelling all click events.

## Fix

Use the existing `__zr` check pattern (already used in the `mousemove` handler at line ~424) to detect when `_downEl` was removed from zrender due to element recreation. If the element was removed (i.e., `_downEl.__zr` is falsy), allow the click to proceed to the new element at the same position.

The `mousemove` handler already uses this pattern:
```ts
if (lastHoveredTarget && !lastHoveredTarget.__zr) {
    lastHovered = this.findHover(lastHovered.x, lastHovered.y);
}
```

## Testing

- Clicking legend items works correctly when `setOption` is called at 60fps
- Dragging (pan/zoom) is unaffected — the `mousemove` distance check (> 4px) still applies
- Normal click behavior is preserved when elements are not recreated
