### PR TITLE
fix(text): use contentHeight for outerHeight to fix vertical alignment

### DIFF
--- a/src/graphic/helper/parseText.ts
+++ b/src/graphic/helper/parseText.ts
@@ -287,7 +287,11 @@ export function parsePlainText(
     }
 
     // Calculate real text width and height
-    let outerHeight = height;
+    // Use contentHeight (actual rendered text height) for outerHeight
+    // instead of style.height (which may be the truncation boundary).
+    // style.height should only serve as the truncation boundary;
+    // outerHeight is used for vertical alignment placement.
+    let outerHeight = contentHeight;
     let contentWidth = 0;
     const fontMeasureInfo = ensureFontMeasureInfo(font);
     for (let i = 0; i < lines.length; i++) {
@@ -562,7 +566,11 @@ export function parseRichText(
     }
 
     contentBlock.outerWidth = contentBlock.width = retrieve2(topWidth, calculatedWidth);
-    contentBlock.outerHeight = contentBlock.height = retrieve2(topHeight, calculatedHeight);
+    // Separating outerHeight (used for vertical alignment) from height (used for truncation).
+    // outerHeight should be the actual rendered text height, not the style.height
+    // which may be the truncation boundary set by e.g. Treemap beforeUpdate.
+    contentBlock.height = retrieve2(topHeight, calculatedHeight);
+    contentBlock.outerHeight = calculatedHeight;
     contentBlock.contentHeight = calculatedHeight;
     contentBlock.contentWidth = calculatedWidth;
 


### PR DESCRIPTION
## What changed

In ,  was being set from  (via the / variable). When  is explicitly set — as Treemap does in its  to establish a truncation boundary —  incorrectly reflects the full block height rather than the actual rendered text height. Since  is what  uses for vertical alignment (), treemap labels in small blocks appeared vertically misaligned (text positioned as if its bounding box were the whole block).

### Fix
- **Simple text path ()**: use  (the actual rendered text height after truncation) for  instead of .
- **Rich text path ()**: separate  from .  now uses  (actual rendered height);  keeps  as the truncation boundary.

 continues to serve only as the truncation boundary;  is used purely for placement.

## Why
Fixes https://github.com/apache/echarts/issues/21673 — Treemap label vertical alignment broken when  is set by  with .

## Tests
All 68 existing zrender unit tests pass, including . Typecheck passes (only pre-existing unrelated error in ).