### PR TITLE
fix: use textContent instead of innerHTML to clear elements

### DIFF
--- a/src/canvas/Painter.ts
+++ b/src/canvas/Painter.ts
@@ -277,7 +277,7 @@ export default class CanvasPainter implements PainterBase {
 
         if (rootStyle) {
             util.disableUserSelect(root);
-            root.innerHTML = '';
+            root.textContent = '';
         }
 
         this.storage = storage;
@@ -1276,7 +1276,7 @@ export default class CanvasPainter implements PainterBase {
     }
 
     dispose() {
-        this.root.innerHTML = '';
+        this.root.textContent = '';
 
         this.root =
         this.storage =

--- a/src/svg-legacy/Painter.ts
+++ b/src/svg-legacy/Painter.ts
@@ -377,7 +377,7 @@ class SVGPainter implements PainterBase {
     }
 
     dispose() {
-        this.root.innerHTML = '';
+        this.root.textContent = '';
 
         this._svgRoot =
             this._backgroundRoot =

--- a/src/svg-legacy/helper/ClippathManager.ts
+++ b/src/svg-legacy/helper/ClippathManager.ts
@@ -117,7 +117,7 @@ export default class ClippathManager extends Definable {
 
             const pathEl = this.getSvgElement(clipPath);
 
-            clipPathEl.innerHTML = '';
+            clipPathEl.textContent = '';
             clipPathEl.appendChild(pathEl);
 
             parentEl.setAttribute('clip-path', getIdURL(id));

--- a/src/svg-legacy/helper/GradientManager.ts
+++ b/src/svg-legacy/helper/GradientManager.ts
@@ -173,7 +173,7 @@ export default class GradientManager extends Definable {
         );
 
         // Remove color stops if exists
-        dom.innerHTML = '';
+        dom.textContent = '';
 
         // Add color stops
         const colors = gradient.colorStops;

--- a/src/svg/Painter.ts
+++ b/src/svg/Painter.ts
@@ -328,7 +328,7 @@ class SVGPainter implements PainterBase {
 
     dispose() {
         if (this.root) {
-            this.root.innerHTML = '';
+            this.root.textContent = '';
         }
 
         this._svgDom =
@@ -340,7 +340,7 @@ class SVGPainter implements PainterBase {
     }
     clear() {
         if (this._svgDom) {
-            this._svgDom.innerHTML = null;
+            this._svgDom.textContent = '';
         }
         this._oldVNode = null;
     }


### PR DESCRIPTION
Assigning to `innerHTML` is a [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) injection sink. On a page sending `require-trusted-types-for 'script'`, the browser rejects the assignment even when the value is an empty string — so zrender throws in `dispose()`, and on clip-path and gradient updates.

`textContent = ''` clears children identically and is not a sink.

`svg/Painter.ts#clear()` assigned `null`, relying on `[LegacyNullToEmptyString]`; it now assigns `''`.